### PR TITLE
#28 Arbitrary checksum support and xattr save on post

### DIFF
--- a/sr_cache.c
+++ b/sr_cache.c
@@ -56,7 +56,7 @@ int sr_cache_check( struct sr_cache_t *cachep, char *cache_basis, char algo, uns
   
      memset( keyhash, 0, SR_SUMHASHLEN);
 
-     memcpy( keyhash, (unsigned char *)ekey, get_sumhashlen(ekey[0]) );
+     memcpy( keyhash, (unsigned char *)ekey, (ekey[0] == 'a') ? strlen((char *)ekey) : get_sumhashlen(ekey[0]) );
 
      HASH_FIND( hh, cachep->data, keyhash, SR_CACHEKEYSZ, c );
   

--- a/sr_config.c
+++ b/sr_config.c
@@ -481,6 +481,13 @@ int sr_add_header(struct sr_config_t *cfg, char *s)
   new_header->value=strdup(eq+1); 
   new_header->next=cfg->user_headers;
   cfg->user_headers=new_header; 
+
+  if ( !strcmp(new_header->key, "sum") && (new_header->value[0] == 'a') ) {
+      log_msg( LOG_DEBUG, "sr_config:sr_add_header:: sum header detected");
+      cfg->sumalgo = new_header->value[0];
+      cfg->sum_preset = strdup(&(new_header->value[2]));
+  }
+
   return(3);
 }
 
@@ -1033,8 +1040,6 @@ int sr_config_parse_option(struct sr_config_t *sr_cfg, char* option, char* arg, 
       sr_cfg->sumalgo = argument[0];
       if ( sr_cfg->sumalgo == 'z' )
           sr_cfg->sumalgoz = argument[2];
-      if ( sr_cfg->sumalgo == 'a' )
-          sr_cfg->sum_preset = strdup(&argument[2]);
       retval=(2);
 
   } else if ( !strcmp( option, "to" ) ) {

--- a/sr_config.c
+++ b/sr_config.c
@@ -1045,6 +1045,8 @@ int sr_config_parse_option(struct sr_config_t *sr_cfg, char* option, char* arg, 
       sr_cfg->sumalgo = argument[0];
       if ( sr_cfg->sumalgo == 'z' )
           sr_cfg->sumalgoz = argument[2];
+      if ( sr_cfg->sumalgo == 'a' )
+          sr_cfg->sum_preset = strdup(&argument[2]);
       retval=(2);
 
   } else if ( !strcmp( option, "to" ) ) {
@@ -1098,6 +1100,7 @@ void sr_config_free( struct sr_config_t *sr_cfg )
   if (sr_cfg->progname) free(sr_cfg->progname);
   if (sr_cfg->randid) free(sr_cfg->randid);
   if (sr_cfg->source) free(sr_cfg->source);
+  if (sr_cfg->sum_preset) free(sr_cfg->sum_preset);
   if (sr_cfg->to) free(sr_cfg->to);
   if (sr_cfg->post_base_url) free(sr_cfg->post_base_url);
 
@@ -1218,6 +1221,7 @@ void sr_config_init( struct sr_config_t *sr_cfg, const char *progname )
   sr_cfg->strip=0;
   sr_cfg->sumalgo='d';
   sr_cfg->sumalgoz='d';
+  sr_cfg->sum_preset=NULL;
   sr_cfg->to=NULL;
   sr_cfg->user_headers=NULL; 
   strcpy( sr_cfg->topic_prefix, "v02.post" );

--- a/sr_config.c
+++ b/sr_config.c
@@ -481,13 +481,6 @@ int sr_add_header(struct sr_config_t *cfg, char *s)
   new_header->value=strdup(eq+1); 
   new_header->next=cfg->user_headers;
   cfg->user_headers=new_header; 
-
-  if ( !strcmp(new_header->key, "sum") && (new_header->value[0] == 'a') ) {
-      log_msg( LOG_DEBUG, "sr_config:sr_add_header:: sum header detected");
-      cfg->sumalgo = new_header->value[0];
-      cfg->sum_preset = strdup(&(new_header->value[2]));
-  }
-
   return(3);
 }
 
@@ -1040,6 +1033,8 @@ int sr_config_parse_option(struct sr_config_t *sr_cfg, char* option, char* arg, 
       sr_cfg->sumalgo = argument[0];
       if ( sr_cfg->sumalgo == 'z' )
           sr_cfg->sumalgoz = argument[2];
+      if ( sr_cfg->sumalgo == 'a' )
+          sr_cfg->sum_preset = strdup(&argument[2]);
       retval=(2);
 
   } else if ( !strcmp( option, "to" ) ) {

--- a/sr_config.c
+++ b/sr_config.c
@@ -117,22 +117,10 @@ void sr_add_path( struct sr_config_t *sr_cfg, const char* option )
            setxattr(p->path, "sum", q->value, strlen(q->value), 0);
 
            // Generate time string
-           time_t raw_time;
-           time(&raw_time);
-
-           struct tm *time_info = gmtime(&raw_time);
-
-           struct timeval tv;
-           gettimeofday(&tv, NULL);
-
-           char s[100];
-           sprintf(s, "%04d%02d%02d%02d%02d%02d.%03d",
-               time_info->tm_year + 1900, time_info->tm_mon + 1, time_info->tm_mday,
-               time_info->tm_hour, time_info->tm_min, time_info->tm_sec,
-               ((unsigned int) tv.tv_usec) / 1000);
+           char *t = sr_time2str(NULL);
 
            // Set mtime xattr
-           setxattr(p->path, "mtime", s, strlen(s), 0);
+           setxattr(p->path, "mtime", t, strlen(t), 0);
 
            break;
        }

--- a/sr_config.c
+++ b/sr_config.c
@@ -114,13 +114,13 @@ void sr_add_path( struct sr_config_t *sr_cfg, const char* option )
    while (q) {
        if (!strcmp("sum", q->key)) {
            // Set sum xattr
-           setxattr(p->path, "user.sum", q->value, strlen(q->value), 0);
+           setxattr(p->path, "user.sr_sum", q->value, strlen(q->value), 0);
 
            // Generate time string
            char *t = sr_time2str(NULL);
 
            // Set mtime xattr
-           setxattr(p->path, "user.mtime", t, strlen(t), 0);
+           setxattr(p->path, "user.sr_mtime", t, strlen(t), 0);
 
            break;
        }

--- a/sr_config.c
+++ b/sr_config.c
@@ -114,13 +114,13 @@ void sr_add_path( struct sr_config_t *sr_cfg, const char* option )
    while (q) {
        if (!strcmp("sum", q->key)) {
            // Set sum xattr
-           setxattr(p->path, "sum", q->value, strlen(q->value), 0);
+           setxattr(p->path, "user.sum", q->value, strlen(q->value), 0);
 
            // Generate time string
            char *t = sr_time2str(NULL);
 
            // Set mtime xattr
-           setxattr(p->path, "mtime", t, strlen(t), 0);
+           setxattr(p->path, "user.mtime", t, strlen(t), 0);
 
            break;
        }

--- a/sr_config.h
+++ b/sr_config.h
@@ -186,6 +186,7 @@ struct sr_config_t {
   int                 strip; /**< number of path elements to strip from posted path  */
   char                sumalgo; /**< checksum algorithm to use.*/
   char                sumalgoz; /**< if algo is z what is the real checksum algorithm to apply.*/
+  char               *sum_preset; /**< if algo is a, pointer to arbitrary checksum string, else NULL.*/
   char               *source; /**< indicates the cluster of origin of a post.*/
   char               *to; /**< indicates destination cluster(s) for a post.*/
   struct sr_topic_t  *topics; /**< list of sub-topics to subscribe to.*/

--- a/sr_post.c
+++ b/sr_post.c
@@ -503,7 +503,7 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec, struct 
   return(m->parts_blkcount);
 }
 
-struct sr_message_t *sr_file2message_seq(const char *pathspec, int seq, struct sr_message_t *m ) 
+struct sr_message_t *sr_file2message_seq(struct sr_context *sr_c, const char *pathspec, int seq, struct sr_message_t *m)
 /*
   Given a message from a "started" file, the prototype message, and a sequence number ( sequence is number of blocks of partsze )
   return the adjusted prototype message.  (requires reading part of the file to checksum it.)
@@ -512,7 +512,8 @@ struct sr_message_t *sr_file2message_seq(const char *pathspec, int seq, struct s
       m->parts_num = seq;
 
       strcpy( m->sum, 
-              set_sumstr( m->sum[0], m->sum[2], pathspec, NULL, m->link, m->parts_blksz, m->parts_blkcount, m->parts_rem, m->parts_num ) 
+              set_sumstr(m->sum[0], m->sum[2], pathspec, sr_c->cfg->sum_preset,
+                  m->link, m->parts_blksz, m->parts_blkcount, m->parts_rem, m->parts_num)
             ); 
 
       if ( !(m->sum) ) 
@@ -541,7 +542,7 @@ void sr_post(struct sr_context *sr_c, const char *pathspec, struct stat *sb )
 
   for( int blk=0; (blk < numblks); blk++ )
   {
-      if ( sr_file2message_seq(pathspec, blk, &m ) ) 
+      if (sr_file2message_seq(sr_c, pathspec, blk, &m))
       {
            if ( sr_c->cfg->cache > 0 ) 
            { 

--- a/sr_util.c
+++ b/sr_util.c
@@ -217,7 +217,7 @@ char *set_sumstr( char algo, char algoz, const char* fn, char* sum_preset, char 
    return a correct sumstring (assume it is big enough)  as per sr_post(7)
    algo = 
      '0' - no checksum, value is random. -> now same as N.
-     'a' - arbitrary checksum, set sum to provided value (partstr)
+     'a' - arbitrary checksum, set sum to provided value (sum_preset)
      'd' - md5sum of block.
      'n' - md5sum of filename (fn).
      'L' - now sha512 sum of link value.

--- a/sr_util.c
+++ b/sr_util.c
@@ -210,7 +210,7 @@ int get_sumhashlen( char algo )
 }
 
 
-char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *linkstr,
+char *set_sumstr( char algo, char algoz, const char* fn, char* sum_preset, char *linkstr,
           unsigned long block_size, unsigned long block_count, unsigned long block_rem, unsigned long block_num 
      )
  /* 
@@ -221,7 +221,7 @@ char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *li
      'd' - md5sum of block.
      'n' - md5sum of filename (fn).
      'L' - now sha512 sum of link value.
-     'p' - md5sum of filename (fn) + partstr. FIXME
+     'p' - md5sum of filename (fn).
      'R' - no checksum, value is random. -> now same as N.
      's' - sha512 sum of block.
      'z' - downstream should recalculate with algo that is argument.
@@ -254,7 +254,10 @@ char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *li
        break;
 
    case 'a' :
-        return(partstr);
+        sumstr[0] = algo;
+        sumstr[1] = ',';
+        strcpy(&sumstr[2], sum_preset);
+        return(sumstr);
         break;
 
    case 'd' :

--- a/sr_util.c
+++ b/sr_util.c
@@ -210,17 +210,18 @@ int get_sumhashlen( char algo )
 }
 
 
-char *set_sumstr( char algo, char algoz, const char* fn, const char* partstr, char *linkstr,
+char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *linkstr,
           unsigned long block_size, unsigned long block_count, unsigned long block_rem, unsigned long block_num 
      )
  /* 
    return a correct sumstring (assume it is big enough)  as per sr_post(7)
    algo = 
      '0' - no checksum, value is random. -> now same as N.
+     'a' - arbitrary checksum, set sum to provided value (partstr)
      'd' - md5sum of block.
      'n' - md5sum of filename (fn).
      'L' - now sha512 sum of link value.
-     'p' - md5sum of filename (fn) + partstr.
+     'p' - md5sum of filename (fn) + partstr. FIXME
      'R' - no checksum, value is random. -> now same as N.
      's' - sha512 sum of block.
      'z' - downstream should recalculate with algo that is argument.
@@ -251,6 +252,10 @@ char *set_sumstr( char algo, char algoz, const char* fn, const char* partstr, ch
        sprintf( sumstr, "%c,%03ld", algo, random()%1000 );
        return(sumstr);
        break;
+
+   case 'a' :
+        return(partstr);
+        break;
 
    case 'd' :
        MD5_Init(&md5ctx);

--- a/sr_util.h
+++ b/sr_util.h
@@ -78,7 +78,7 @@ int get_sumhashlen( char algo );
  return the length of the hash buffer (which includes the 1 char prefix for the type.
   */
 
-char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *linkstr,
+char *set_sumstr( char algo, char algoz, const char* fn, char* sum_preset, char *linkstr,
           unsigned long block_size, unsigned long block_count, unsigned long block_rem, unsigned long block_num
      );
 

--- a/sr_util.h
+++ b/sr_util.h
@@ -59,7 +59,7 @@ void daemonize(int close_stdout);
    return a correct sumstring (assume it is big enough)  as per sr_post(7)
    algo = 
      '0' - no checksum, value is random. -> now same as N.
-     'a' - arbitrary checksum, set sum to provided value (partstr)
+     'a' - arbitrary checksum, set sum to provided value (sum_preset)
      'd' - md5sum of block.
      'n' - md5sum of filename (fn).
      'L' - now sha512 sum of link value.

--- a/sr_util.h
+++ b/sr_util.h
@@ -77,7 +77,7 @@ int get_sumhashlen( char algo );
  return the length of the hash buffer (which includes the 1 char prefix for the type.
   */
 
-char *set_sumstr( char algo, char algoz, const char* fn, const char* partstr, char *linkstr,
+char *set_sumstr( char algo, char algoz, const char* fn, char* partstr, char *linkstr,
           unsigned long block_size, unsigned long block_count, unsigned long block_rem, unsigned long block_num
      );
 

--- a/sr_util.h
+++ b/sr_util.h
@@ -59,6 +59,7 @@ void daemonize(int close_stdout);
    return a correct sumstring (assume it is big enough)  as per sr_post(7)
    algo = 
      '0' - no checksum, value is random. -> now same as N.
+     'a' - arbitrary checksum, set sum to provided value (partstr)
      'd' - md5sum of block.
      'n' - md5sum of filename (fn).
      'L' - now sha512 sum of link value.


### PR DESCRIPTION
Tested using a local setup: 
 - sr_config local xattr setting
 - sr_config header processing
 - sr_cpost arbitrary checksum option as sum header
 - cpump transmission
They all appear to work as they should.
Unit tests will be included in unit test overhaul (for another branch and pull request, this is getting to big)
Flow test passed!