### PR TITLE
added libsarra.so symlink to libsarrac-dev pkg

### DIFF
--- a/debian/libsarrac-dev.install
+++ b/debian/libsarrac-dev.install
@@ -1,1 +1,2 @@
 build/include/*  usr/include/
+build/lib/libsarr*.so  usr/lib/


### PR DESCRIPTION
#75

Confirmed that libsarra.so symlink was present in libsarrac-dev after building debian packages.