### PR TITLE
Feature move metrics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,14 +2,14 @@ metpx-sr3c (3.23.11) UNRELEASED; urgency=medium
 
   * just moving version marker away from release.
 
- -- Peter Silva <peter@blacklab>  Tue, 27 Jun 2023 14:25:29 -0400
+ -- Peter Silva <peter@bsqt.homeip.net>  Tue, 27 Jun 2023 14:25:29 -0400
 
 metpx-sr3c (3.23.06) unstable; urgency=medium
 
   * default topicPrefix is v03, not v03.post 
   * #113 v03 message format change "integrity" to "identity"
 
- -- Peter Silva <peter@blacklab>  Tue, 09 May 2023 16:43:58 -0400
+ -- Peter Silva <peter@bsqt.homeip.net>  Tue, 09 May 2023 16:43:58 -0400
 
 metpx-sr3c (3.23.05) unstable; urgency=medium
 
@@ -244,7 +244,7 @@ sarrac (2.19.11b1) unstable; urgency=medium
   * fix: #67 post_exchange_suffix was not working.
   * new: printing hostname in options. 
 
- -- Peter Silva <peter@blacklab>  Thu, 31 Oct 2019 22:04:30 -0400
+ -- Peter Silva <peter@bsqt.homeip.net>  Thu, 31 Oct 2019 22:04:30 -0400
 
 sarrac (2.19.10b1) unstable; urgency=medium
 
@@ -272,7 +272,7 @@ sarrac (2.19.07b2) unstable; urgency=medium
   * noticed a missing comma in json output (not v03 related.)
   * added option to omit libjson (documented in Makefile) to avoid dependency. 
 
- -- Peter Silva <peter@blacklab>  Thu, 25 Jul 2019 20:48:36 -0400
+ -- Peter Silva <peter@bsqt.homeip.net>  Thu, 25 Jul 2019 20:48:36 -0400
 
 sarrac (2.19.07b1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-metpx-sr3c (3.23.07) UNRELEASED; urgency=medium
+metpx-sr3c (3.23.11) UNRELEASED; urgency=medium
 
   * just moving version marker away from release.
 

--- a/sr_config.c
+++ b/sr_config.c
@@ -1768,11 +1768,11 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 	}
 	// MetricsFilename
 	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/%s/%s/i%03d.metrics", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/%s/metrics/%s_%s_%03d.json", home, sr_cfg->appname,
 			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	else {
-		sprintf(p, "%s/.cache/%s/%s/%s/i%03d.metrics", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/metrics/%s_%s_%03d.json", home, sr_cfg->appname,
 			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	sr_cfg->metricsFilename = strdup(p);

--- a/sr_config.c
+++ b/sr_config.c
@@ -1749,12 +1749,12 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 	}
 	// pidfn statehost
 	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/%s/%s/i%03d.pid", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/%s/%s/%s/i%02d.pid", home, sr_cfg->appname,
 			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	// pidfn default
 	else {
-		sprintf(p, "%s/.cache/%s/%s/%s/i%03d.pid", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/%s/%s/i%02d.pid", home, sr_cfg->appname,
 			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 
@@ -1768,25 +1768,25 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 	}
 	// MetricsFilename
 	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/metrics/%s_%s_%03d.json", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
 			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	else {
-		sprintf(p, "%s/.cache/%s/metrics/%s_%s_%03d.json", home, sr_cfg->appname,
+		sprintf(p, "%s/.cache/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
 			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	sr_cfg->metricsFilename = strdup(p);
 	
 	// cachefn statehost
 	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/%s/%s/recent_files_%03d.cache",
+		sprintf(p, "%s/.cache/%s/%s/%s/%s/recent_files_%02d.cache",
 			home, sr_cfg->appname, val, sr_cfg->progname,
 			sr_cfg->configname, sr_cfg->instance);
 	}
 	// cachefn default
 	else {
 		// FIXME: open and read cache file if present. seek to end.
-		sprintf(p, "%s/.cache/%s/%s/%s/recent_files_%03d.cache",
+		sprintf(p, "%s/.cache/%s/%s/%s/recent_files_%02d.cache",
 			home, sr_cfg->appname, sr_cfg->progname, sr_cfg->configname,
 			sr_cfg->instance);
 	}


### PR DESCRIPTION
do the C part of moving the metrics collection stuf as per

https://github.com/MetPX/sarracenia/issues/793 - move metrics to sub-directory for cloud compatibility

Also changes the instance numbers in instance files (such as pid, log, and metrics) to two digit ones to match the python implementation.

Note that previous tests have led us to conclude that beyond 40 or so, there was not much accelleration.  that was the rational behind lowering the instance template on the python side.  This was a long time ago, and new tests could be warranted, but for now, two digits seems right.

