### PR TITLE
fixes #118 management of metrics dir and files

### DIFF
--- a/sr_config.c
+++ b/sr_config.c
@@ -1705,6 +1705,34 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 		strcat(p, sr_cfg->configname);
 		mkdir(p, 0700);
 	}
+	// if the metrics directory is missing, build it.
+	if (val) {
+		sprintf(p, "%s/.cache/%s/%s/metrics", home, sr_cfg->appname, val);
+	} else {
+		sprintf(p, "%s/.cache/%s/metrics", home, sr_cfg->appname);
+	}
+	ret = stat(p, &sb);
+	if (ret) {
+		sprintf(p, "%s/.cache/%s", home, sr_cfg->appname);
+		if (val) {
+			strcat(p, "/");
+			strcat(p, val);
+			mkdir(p, 0700);
+		}
+		strcat(p, "/metrics");
+		mkdir(p, 0700);
+        }
+	// MetricsFilename
+	if (val) {
+		sprintf(p, "%s/.cache/%s/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
+			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
+	}
+	else {
+		sprintf(p, "%s/.cache/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
+			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
+	}
+	sr_cfg->metricsFilename = strdup(p);
+
 	// if the log directory is missing, build it.
 	if (val) {
 		sprintf(p, "%s/.cache/%s/%s/log", home, sr_cfg->appname, val);
@@ -1743,7 +1771,7 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 		sr_cfg->sleep = 5.0; // if you're "starting" then you want to run a daemon, so sleep must be > 0
         }
 	if (sr_cfg->log) {
-		sr_log_setup(sr_cfg->logfn, sr_cfg->chmod_log,
+		sr_log_setup(sr_cfg->logfn, sr_cfg->metricsFilename, sr_cfg->logMetrics, sr_cfg->chmod_log,
 			     sr_cfg->debug ? LOG_DEBUG : (sr_cfg->loglevel),
 			     sr_cfg->logrotate, sr_cfg->logrotate_interval);
 	}
@@ -1766,16 +1794,6 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 		sr_cfg->pid = atoi(p);
 		fclose(f);
 	}
-	// MetricsFilename
-	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
-			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
-	}
-	else {
-		sprintf(p, "%s/.cache/%s/metrics/%s_%s_%02d.json", home, sr_cfg->appname,
-			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
-	}
-	sr_cfg->metricsFilename = strdup(p);
 	
 	// cachefn statehost
 	if (val) {

--- a/sr_context.c
+++ b/sr_context.c
@@ -279,10 +279,12 @@ void sr_context_metrics_cumulative_write(struct sr_context *sr_c)
                 datestamp[8] = c;
 
                 f = fopen( cumulativeFilename, "a+" );
-                fprintf( f, "\"%s\": { \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f } }, \n" ,
-                        datestamp, sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping
-                );
-                fclose(f);
+		if (f) {
+                        fprintf( f, "\"%s\": { \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f } }, \n" ,
+                                datestamp, sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping
+                        );
+                        fclose(f);
+		}
 
         }
 }

--- a/sr_util.h
+++ b/sr_util.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdbool.h>
 
 #include <time.h>
 #include <openssl/sha.h>
@@ -34,7 +35,7 @@ void sr_log_msg(const int prio, const char *format, ...);
 
 #endif
 
-void sr_log_setup(const char *fn, mode_t mode, int level, int lr, int lri);
+void sr_log_setup(const char *fn, const char *metricsfn, bool logMetricsFlag, mode_t mode, int level, int lr, int lri);
 // set up logging to the named file, suppressing messages of lower severity 
 // logrotation is a floating point number of seconds, indicating number of days to retain.
 


### PR DESCRIPTION
closes #118 

there is a race condition when starting C and python components, in that only the Python components create the metrics directory, so if a C library starts too early, it will crash trying to open the metrics file in a directory that doesn't exist.  I think this may be the reason behind some of the crashes of the flow tests on github, where we can see the failed components are all zero results for the C components.

With this branch, the c now independently:
* gracefully ignores the problem if it fails to open a metrics file (instead of crashing.)
* creates the metrics directory on startup if need be.
* removes excessive metrics files  (following the same logic as log file management.)

Tested this with dynamic flow tests and then setting:
```

logRotateInterval 20

```
making a rotation happen every 20 seconds.  I could see that the logCount (defaults to 5) was properly enforced.

