### PR TITLE
Issue120 - report broker side queue size.

### DIFF
--- a/sr_consume.c
+++ b/sr_consume.c
@@ -86,6 +86,7 @@ int sr_consume_setup(struct sr_context *sr_c)
 	amqp_boolean_t passive = 0;
 	amqp_boolean_t exclusive = 0;
 	amqp_boolean_t auto_delete = 0;
+	amqp_queue_declare_ok_t *r;
 	struct sr_binding_s *t;
 	static amqp_basic_properties_t props;
 	static amqp_table_t table;
@@ -121,12 +122,16 @@ int sr_consume_setup(struct sr_context *sr_c)
 
 	//amqp_queue_declare_ok_t *r = 
 	if (sr_c->cfg->queueDeclare) {
-		amqp_queue_declare(sr_c->cfg->broker->conn,
-				   1,
+		r = amqp_queue_declare(sr_c->cfg->broker->conn,
+				   2,
 				   amqp_cstring_bytes(sr_c->cfg->queuename),
 				   passive, sr_c->cfg->durable, exclusive, auto_delete, table);
 		/* FIXME how to parse r for error? */
-
+                
+		if (r) {
+	               sr_log_msg(LOG_INFO, "queue declared: %p messages in queue: %d\n", 
+		                sr_c->cfg->queuename, r->message_count );
+                }
 		reply = amqp_get_rpc_reply(sr_c->cfg->broker->conn);
 		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
 			sr_amqp_reply_print(reply, "queue declare failed");

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -740,7 +740,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 
 	// rate limiting.
 	//sr_log_msg( LOG_INFO, "rateMax: %d, consumed_this_second: %d\n", 
-			sr_c->cfg->messageRateMax, consumed_this_second );
+	//		sr_c->cfg->messageRateMax, consumed_this_second );
         if (sr_c->cfg->messageRateMax > 0) {
                 if (consumed_this_second >= sr_c->cfg->messageRateMax) {
                         sr_log_msg(LOG_INFO, "messageRateMax %d per second sleeping for a second.\n",

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -739,7 +739,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
         }
 
 	// rate limiting.
-	sr_log_msg( LOG_INFO, "rateMax: %d, consumed_this_second: %d\n", 
+	//sr_log_msg( LOG_INFO, "rateMax: %d, consumed_this_second: %d\n", 
 			sr_c->cfg->messageRateMax, consumed_this_second );
         if (sr_c->cfg->messageRateMax > 0) {
                 if (consumed_this_second >= sr_c->cfg->messageRateMax) {

--- a/sr_context.c
+++ b/sr_context.c
@@ -286,8 +286,9 @@ void sr_context_metrics_cumulative_write(struct sr_context *sr_c)
                 datestamp[8] = c;
 
                 f = fopen( cumulativeFilename, "a+" );
-                fprintf( f, "\"%s\": { \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f } }, \n" ,
-                        datestamp, sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping
+                fprintf( f, "\"%s\": { \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f, \"brokerQueuedMessageCount\": %d } }, \n" ,
+                        datestamp, sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, 
+			sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping, sr_c->metrics.brokerQueuedMessageCount 
                 );
                 fclose(f);
 
@@ -299,6 +300,7 @@ void sr_context_metrics_reset(struct sr_context *sr_c)
 	struct timespec tnow;
 
         sr_context_metrics_cumulative_write(sr_c);
+        sr_c->metrics.brokerQueuedMessageCount = 0;
         sr_c->metrics.rxGoodCount = 0;
         sr_c->metrics.rxBadCount = 0;
         sr_c->metrics.rejectCount = 0;
@@ -457,9 +459,9 @@ void sr_context_metrics_write(struct sr_context *sr_c)
 	FILE *f;
         
 	f = fopen( sr_c->cfg->metricsFilename, "w" );
-        fprintf( f, "{ \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f } }\n" ,
-			sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping 
-		);
+        fprintf( f, "{ \"context\" : { \"rxGoodCount\": %d, \"rxBadCount\": %d, \"rejectCount\": %d, \"txGoodCount\": %d, \"last_housekeeping\": %f , \"brokerQueuedMessageCount\": %d } }\n" ,
+		sr_c->metrics.rxGoodCount, sr_c->metrics.rxBadCount, sr_c->metrics.rejectCount, 
+		sr_c->metrics.txGoodCount, sr_c->metrics.last_housekeeping,  sr_c->metrics.brokerQueuedMessageCount ); 
 	fclose(f);
 }
 

--- a/sr_context.h
+++ b/sr_context.h
@@ -44,6 +44,7 @@
 #include "sr_config.h"
 
 struct sr_metrics_s {
+    int brokerQueuedMessageCount;
     int rxGoodCount;
     int rxBadCount;
     int rejectCount;

--- a/sr_context.h
+++ b/sr_context.h
@@ -57,7 +57,6 @@ struct sr_context {
 	const char *file;
 	const char *post_baseUrl;
 	amqp_socket_t *socket;
-	amqp_connection_state_t conn;
 	int port;
 	struct sr_config_s *cfg;
 	struct sr_metrics_s metrics;


### PR DESCRIPTION
closes #120 

Implementation to match python... https://github.com/MetPX/sarracenia/issues/767

Also implemented messageRateMax on the consumer side, trying to catch messages
in the broker side queue. It turns out that C setting are such that it greedily ingests
all messages regardless of queue settings, so the broker side queue are always empty.
see #121 for details.

It works, but the metrics are always zero as a result.
