### PR TITLE
on #109 consumer connection recovery was broken.

### DIFF
--- a/sr3_cpump.c
+++ b/sr3_cpump.c
@@ -342,7 +342,10 @@ int main(int argc, char **argv)
 		// inlet: from queue, json, tree.
 		m = sr_consume(sr_c);
 
-		if (!m) {
+                if (m==SR_CONSUME_BROKEN) {
+                        sr_c = force_good_connection_and_bindings(sr_c);
+			continue;
+		} else if (!m) {
 			// exponential back-off if queue checks to reduce cpu.
                         no_messages_tally += 1;
 			tsleep.tv_sec = 0L; 

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -833,21 +833,21 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 
 	if (result == AMQP_STATUS_TIMEOUT ) {
 	        //sr_log_msg(LOG_DEBUG, "no messages ready.\n" );
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 	if (result < 0) {
 		sr_log_msg(LOG_ERROR, "wait_frame bad result: %d. aborting connection.\n", result);
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 	if (frame.frame_type != AMQP_FRAME_METHOD) {
 		sr_log_msg(LOG_ERROR, "bad FRAME_METHOD: %d. aborting connection.\n",
 			   frame.frame_type);
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 	if (frame.payload.method.id != AMQP_BASIC_DELIVER_METHOD) {
 		sr_log_msg(LOG_ERROR, "bad payload method: %d. aborting connection.\n",
 			   frame.payload.method.id);
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 
 	d = (amqp_basic_deliver_t *) frame.payload.method.decoded;
@@ -872,12 +872,12 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 
 	if (result < 0) {
 		sr_log_msg(LOG_ERROR, "error receiving frame! aborting connection.");
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 
 	if (frame.frame_type != AMQP_FRAME_HEADER) {
 		sr_log_msg(LOG_ERROR, "Expected header! aborting connection.");
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	}
 
 	p = (amqp_basic_properties_t *) frame.payload.properties.decoded;
@@ -992,7 +992,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 			sr_log_msg(LOG_WARNING,
 				   "broken message received: wait_frame returned %d. aborting connection.\n",
 				   result);
-			return (NULL);
+			return (SR_CONSUME_BROKEN);
 		}
 		if (frame.frame_type != AMQP_FRAME_BODY) {
 			sr_log_msg(LOG_CRITICAL, "Expected body! aborting connection.");
@@ -1013,7 +1013,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 		sr_log_msg(LOG_ERROR,
 			   "incomplete message, received: %lu bytes, expected: %lu bytes.\n",
 			   (long)body_received, (long)body_target);
-		return (NULL);
+		return (SR_CONSUME_BROKEN);
 	} else {
 		sr_log_msg(LOG_DEBUG, "complete message, received: %lu bytes \n",
 			   (unsigned long)body_received);

--- a/sr_consume.h
+++ b/sr_consume.h
@@ -103,7 +103,15 @@ void sr_message_2url(struct sr_message_s *m);
 
  */
 
+#define SR_CONSUME_BROKEN (struct sr_message_s *)(0x37)
+
 struct sr_message_s *sr_consume(struct sr_context *sr_c);
+/*
+ * return value:
+ *    * pointer to struct of the message received.
+ *    * NULL - connection is good, no message currently available.
+ *    * SR_CONSUME_BROKEN: connection is bad, restart.
+ */
 
 bool sr_message_valid(struct sr_message_s *m);
 /*


### PR DESCRIPTION
None of the *flakey_broker* or *restart_server* tests succeed in the flow tests, because the code, since the #109 code was introduced, no longer recovers after a connection gets broken.  This restores the error recovery logic from before (without losing the non-blocking.)
