### PR TITLE
when used as shovel/winnow, it constantly re-declares the queue.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+metpx-sr3c (3.23.11p3) UNRELEASED; urgency=medium
+
+  * fixed #130 DOS attack by constant re-connections.
+
+ -- peter <peter@bsqt.homeip.net>  Fri, 24 Nov 2023 17:47:59 -0500
+
 metpx-sr3c (3.23.11p2) unstable; urgency=medium
 
   * another #109 related fix, restoring connection repair when broken.

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -135,7 +135,7 @@ signed int sr_consume_queue_declare(struct sr_context *sr_c, amqp_boolean_t pass
 		/* FIXME how to parse r for error? */
                 
 		if (r) {
-	               sr_log_msg(LOG_INFO, "queue declared: %p messages in queue: %d\n", 
+	               sr_log_msg(LOG_INFO, "queue declared: %s messages in queue: %d\n", 
 		                sr_c->cfg->queuename, r->message_count );
 		       message_count = r->message_count;
 		       sr_c->metrics.brokerQueuedMessageCount = message_count;

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -804,7 +804,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 		reply = amqp_get_rpc_reply(sr_c->cfg->broker->conn);
 		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
 			sr_amqp_reply_print(reply, "basic_consume failed");
-			return (NULL);
+			return (SR_CONSUME_BROKEN);
 		}
 		sprintf(consumer_tag, "host_%s_pid_%d", sr_local_fqdn(), sr_c->cfg->pid);
 
@@ -819,7 +819,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 		reply = amqp_get_rpc_reply(sr_c->cfg->broker->conn);
 		if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
 			sr_amqp_reply_print(reply, "basic_consume failed");
-			return (NULL);
+			return (SR_CONSUME_BROKEN);
 		}
 		sr_c->cfg->broker->started = 1;
 	}
@@ -833,7 +833,7 @@ struct sr_message_s *sr_consume(struct sr_context *sr_c)
 
 	if (result == AMQP_STATUS_TIMEOUT ) {
 	        //sr_log_msg(LOG_DEBUG, "no messages ready.\n" );
-		return (SR_CONSUME_BROKEN);
+		return (NULL);
 	}
 	if (result < 0) {
 		sr_log_msg(LOG_ERROR, "wait_frame bad result: %d. aborting connection.\n", result);


### PR DESCRIPTION
a mixup with the return code when checking for messages means that whenever there are no new messages available, sr3_cpump concludes that the connection has brokern, so it spams the boker with continuous broker connection requests.

