### PR TITLE
Handle renameat2 on RHEL 8 and systems with glibc < 2.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ LIBCLOCATION=$(shell ldd /bin/sh | awk '/libc\.so\./ { print; }' | cut -d' ' -f3
 # also remove -ljson-c from EXT_LIB declaration.
 # to work with sr3, change SR_APPNAME=\"sr3\" ... otherwise will be managed by version 2. 
 # on Power9, -fstack-check  causes coredumps, so removed for now.
+# On RHEL8, add -DINTERCEPT_SYSCALL to handle cases where mv calls syscall directly, instead of calling renameat2.
+# See sarrac issue #145 for more information about syscall/renameat2.
 
 CFLAGS = -DHAVE_JSONC -DSR_APPNAME=\"sr3\" -DFORCE_LIBC_REGEX=\"$(LIBCLOCATION)\" -fPIC -ftest-coverage -std=gnu99 -Wall -g -D_GNU_SOURCE $(RABBIT_INCDIR)
 


### PR DESCRIPTION
RedHat 8 has glibc 2.28 which provides renameat2, but its `mv` command uses `syscall(316...)` instead of renameat2 provided by glibc.

On RHEL8, we have to manually define INTERCEPT_SYSCALL at compile time. On systems with glibc < 2.28, it's automatically defined with 

```c
#if !__GLIBC_PREREQ(2,28)
#define INTERCEPT_SYSCALL
#endif
```

With INTERCEPT_SYSCALL defined, test_shim_post fails on RHEL8 with 19 good and 2 bad (RESULT: BAD! missing expected {'sha512': 1} for 160 stdout redirection in a subdir) instead of 5 bad without it.


With INTERCEPT_SYSCALL:
```
RESULT: BAD! missing expected {'sha512': 1} for 160 stdout redirection in a subdir
RESULT: BAD! missing expected {'sha512': 1} for 180 stdout redirection in a subsubdir
RESULT: summary: good: 19, bad 2, total 21
```


Without INTERCEPT_SYSCALL:
```
RESULT: BAD! missing expected {'rename': 1} for 050 rename directory
RESULT: BAD! missing expected {'rename': 1} for 120 moving a file.
RESULT: BAD! missing expected {'sha512': 1} for 160 stdout redirection in a subdir
RESULT: BAD! missing expected {'sha512': 1} for 180 stdout redirection in a subsubdir
RESULT: BAD! missing expected {'rename': 1} for 190 renaming subdirs should cause file rename events.
RESULT: summary: good: 16, bad 5, total 21
```