### PR TITLE
Issue148 -  posting corrupt topic header in rare case (but common in tests.)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
-metpx-sr3c (3.24.03rc1) unstable; urgency=medium
+metpx-sr3c (3.24.07rc1) unstable; urgency=medium
 
+  * support #147 coreutils using syscall instead of renameat2 on redhat8 and
+    ubuntu 18.
+  * fix #148 sr3_cpost posting messages with corrupt topics if relPath blank.
   * fix #141 sr3_cpost in a tree being mirrored (conflict with shim)
   * tests: fix for link modification times cannot be preserved.
   * test fixes for changes in python side.

--- a/sr_post.c
+++ b/sr_post.c
@@ -782,13 +782,11 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 	if ( strlen(m->relPath) > 0 ) {
 		strcat(tmprk, ".");
 		strcat(tmprk, m->relPath + ((strlen(m->relPath)>1)&&(*(m->relPath) == '/')));
-        } else {
-		strcpy(tmprk, "");
+		if (strlen(tmprk) > 255)
+			tmprk[255] = '\0';
 	}
-	if (strlen(tmprk) > 255)
-		tmprk[255] = '\0';
-
 	strcpy(m->routing_key, tmprk);
+
 
 	lasti = strlen(sr_c->cfg->post_topicPrefix);
 	for (int i = lasti; i < strlen(m->routing_key); i++) {

--- a/sr_post.c
+++ b/sr_post.c
@@ -776,11 +776,15 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 			s += pmatch[0].rm_eo;
 		}
 	}
+
 	// use tmprk variable to fix  255 AMQP_SS_LEN limit
 	strcpy(tmprk, sr_c->cfg->post_topicPrefix);
-	strcat(tmprk, ".");
-	strcat(tmprk, m->relPath + (*(m->relPath) == '/'));
-
+	if ( strlen(m->relPath) > 0 ) {
+		strcat(tmprk, ".");
+		strcat(tmprk, m->relPath + (*(m->relPath) == '/'));
+        } else {
+		strcpy(tmprk, "");
+	}
 	if (strlen(tmprk) > 255)
 		tmprk[255] = '\0';
 

--- a/sr_post.c
+++ b/sr_post.c
@@ -781,7 +781,7 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 	strcpy(tmprk, sr_c->cfg->post_topicPrefix);
 	if ( strlen(m->relPath) > 0 ) {
 		strcat(tmprk, ".");
-		strcat(tmprk, m->relPath + (*(m->relPath) == '/'));
+		strcat(tmprk, m->relPath + ((strlen(m->relPath)>1)&&(*(m->relPath) == '/')));
         } else {
 		strcpy(tmprk, "");
 	}


### PR DESCRIPTION
* this is a confluence of two things that happenned over the past year: added directory postings, and forcing *relPath* is always relative.
* If you want to post a message at the root of a baseURL tree, the correct *relPath* is an empty string.
* *relPath* is used to derive the topic, and copies garbage into the topic when relPath is too short.
* It's only multiple patches because I hemmed and hawed about how to do it. Also updated changelog to reflect @reidsunderland 's recently merged PR as well as this one.

This problem causes a lot of flow tests to fail.

