### PR TITLE
More fixes for #145

### DIFF
--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1445,7 +1445,7 @@ long int syscall(long int __sysno, ...)
 		sr_log_msg(logctxptr,LOG_ERROR, "syscall (%ld) no syscall_fn_ptr!\n", __sysno);
 		status = -1;
 	}
-	sr_shimdebug_msg(1, "syscall %ld return %ld\n", status);
+	sr_shimdebug_msg(1, "syscall %ld return %ld\n", __sysno, status);
 	return status;
 }
 #endif


### PR DESCRIPTION
I'm now handling the syscalls that we found were being used during our tests. And switched to using the portable SYS_<something> names instead of the hardcoded syscall numbers, which are platform dependent.