### PR TITLE
the fix for >100 instances does not understand C component instances.…

### DIFF
--- a/sr_config.c
+++ b/sr_config.c
@@ -1790,13 +1790,13 @@ int sr_config_finalize(struct sr_config_s *sr_cfg, const int is_consumer)
 	}
 	// pidfn statehost
 	if (val) {
-		sprintf(p, "%s/.cache/%s/%s/%s/%s/i%02d.pid", home, sr_cfg->appname,
-			val, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
+		sprintf(p, "%s/.cache/%s/%s/%s/%s/%s_%s_%02d.pid", home, sr_cfg->appname,
+			val, sr_cfg->progname, sr_cfg->configname,  sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 	// pidfn default
 	else {
-		sprintf(p, "%s/.cache/%s/%s/%s/i%02d.pid", home, sr_cfg->appname,
-			sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
+		sprintf(p, "%s/.cache/%s/%s/%s/%s_%s_%02d.pid", home, sr_cfg->appname,
+			sr_cfg->progname, sr_cfg->configname, sr_cfg->progname, sr_cfg->configname, sr_cfg->instance);
 	}
 
 	sr_cfg->pidfile = strdup(p);
@@ -2609,8 +2609,8 @@ void sr_config_list(struct sr_config_s *sr_cfg)
 			*s = '\0';
 		}
 
-		sprintf(p, "%s/.cache/%s/%s/%s/i001.pid", getenv("HOME"),
-			sr_cfg->appname, sr_cfg->progname, d->d_name);
+		sprintf(p, "%s/.cache/%s/%s/%s/%s_%s_01.pid", getenv("HOME"),
+			sr_cfg->appname, sr_cfg->progname, sr_cfg->appname, sr_cfg->progname, d->d_name);
 		f = fopen(p, "r");
 		if (f)		// read the pid from the file.
 		{


### PR DESCRIPTION
It turns out that this: https://github.com/MetPX/sarracenia/pull/1226
changed how sr3 looks for instance pid files by looking for underscores in them.
The ones created by C components were just i99.pid ... no underscrore, so sr3 was wonky for running C components.

This patch makes the C write instance files with the same conventions as the python ones.
