### PR TITLE
Add more syscalls

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,16 @@
-metpx-sr3c (3.24.09rc1) UNRELEASED; urgency=medium
+metpx-sr3c (3.24.10rc1) unstable; urgency=medium
+
+  * added more syscalls (getcpu, mremap, shmat, shmdt)
+
+ -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Thu, 03 Oct 2024 13:26:44 +0000
+
+metpx-sr3c (3.24.09rc2) unstable; urgency=medium
+
+  * added additional syscall passthroughs for syscalls used by MPI (#145)
+
+ -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Thu, 03 Oct 2024 13:26:44 +0000
+
+metpx-sr3c (3.24.09rc1) unstable; urgency=medium
 
   * need syscall gettid implementation for redhat 8.
   * fix #157 to have cpost print messages more often to convince sr3 it is not

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ metpx-sr3c (3.24.10rc1) unstable; urgency=medium
 
   * added more syscalls (getcpu, mremap, shmat, shmdt)
 
- -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Thu, 03 Oct 2024 13:26:44 +0000
+ -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Tue, 08 Oct 2024 14:55:36 +0000
 
 metpx-sr3c (3.24.09rc2) unstable; urgency=medium
 

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1436,6 +1436,9 @@ long int syscall(long int __sysno, ...)
 	} else if (__sysno == SYS_getpid && syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld --> getpid, will pass along\n", __sysno);
 		status = syscall_fn_ptr(__sysno);
+	} else if (__sysno == SYS_gettid && syscall_fn_ptr) {
+		sr_shimdebug_msg(1, "syscall %ld --> gettid, will pass along\n", __sysno);
+		status = syscall_fn_ptr(__sysno);
 	} else if (syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld NOT IMPLEMENTED\n", __sysno);
 		sr_log_msg(logctxptr,LOG_ERROR, "syscall (%ld) not implemented\n", __sysno);

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1628,6 +1628,7 @@ long int syscall(long int __sysno, ...)
 	} else if (__sysno == SYS_gettid && syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld --> gettid, will pass along\n", __sysno);
 		status = syscall_fn_ptr(__sysno);
+	#ifdef SYS_shmat
 	} else if (__sysno == SYS_shmat && syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld --> shmat, will pass along\n", __sysno);
 		va_start(args, __sysno);
@@ -1636,12 +1637,15 @@ long int syscall(long int __sysno, ...)
 		int shmflg = va_arg(args, int);
 		va_end(args);
 		status = syscall_fn_ptr(__sysno, shmid, shmaddr, shmflg);
+	#endif
+	#ifdef SYS_shmdt
 	} else if (__sysno == SYS_shmdt && syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld --> shmdt, will pass along\n", __sysno);
 		va_start(args, __sysno);
 		void *shmaddr = va_arg(args, void*);
 		va_end(args);
 		status = syscall_fn_ptr(__sysno, shmaddr);
+	#endif
 	} else if (syscall_fn_ptr) {
 		sr_shimdebug_msg(1, "syscall %ld NOT IMPLEMENTED\n", __sysno);
 		sr_log_msg(logctxptr,LOG_ERROR, "syscall (%ld) not implemented\n", __sysno);


### PR DESCRIPTION
For issue #145 , adds more syscall passthroughs:

-  brk
-  epoll_create
-  epoll_create
-  epoll_ctl
-  epoll_pwait
-  epoll_wait
-  get_mempolicy
-  getcpu
-  gettid
-  ipc
-  madvise
-  mbind
-  migrate_pages
-  mmap
-  move_pages
-  mremap
-  munmap
-  process_vm_readv
-  process_vm_readv
-  process_vm_writev
-  process_vm_writev
-  sched_getaffinity
-  sched_getaffinity
-  sched_setaffinity
-  sched_setaffinity
-  set_mempolicy
-  shmat
-  shmdt