### PR TITLE
Sarracenia 1270 support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -24,7 +24,7 @@ metpx-sr3c (3.24.09rc1) unstable; urgency=medium
   * fix #158 log rotation.
   * fix #143 include files in main conf directory and hostname implementation.
 
- -- SSC-5CD2310S60 <peter@bsqt.homeip.net>  Mon, 23 Sep 2024 16:19:20 -0400
+ -- SSC-5CD2310S60 <peter.silva@ssc-spc.gc.ca>  Mon, 23 Sep 2024 16:19:20 -0400
 
 metpx-sr3c (3.24.07) unstable; urgency=medium
 
@@ -47,14 +47,14 @@ metpx-sr3c (3.23.11p3) unstable; urgency=medium
 
   * fixed #130 DOS attack by constant re-connections.
 
- -- peter <peter@bsqt.homeip.net>  Fri, 24 Nov 2023 17:47:59 -0500
+ -- peter <peter.silva@ssc-spc.gc.ca>  Fri, 24 Nov 2023 17:47:59 -0500
 
 metpx-sr3c (3.23.11p2) unstable; urgency=medium
 
   * another #109 related fix, restoring connection repair when broken.
   * coredump in log rotation cleanup code.
 
- -- Peter Silva <peter@blacklab>  Thu, 16 Nov 2023 17:37:22 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 16 Nov 2023 17:37:22 -0500
 
 metpx-sr3c (3.23.11p1) unstable; urgency=medium
 
@@ -66,7 +66,7 @@ metpx-sr3c (3.23.11p1) unstable; urgency=medium
   * fix #109: now doesn't block waiting for messages, sr3 status not always "hung"
   * messageRateMax implemented on consumer side.
 
- -- peter <peter@bsqt.homeip.net>  Fri, 03 Nov 2023 22:45:51 -0400
+ -- peter <peter.silva@ssc-spc.gc.ca>  Fri, 03 Nov 2023 22:45:51 -0400
 
 metpx-sr3c (3.23.11) unstable; urgency=medium
 
@@ -74,14 +74,14 @@ metpx-sr3c (3.23.11) unstable; urgency=medium
   * moved metrics files to separate directory for easier monitoring.
   * change instance file names to be two digit, instead of 3 to match python.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 27 Jun 2023 14:25:29 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 27 Jun 2023 14:25:29 -0400
 
 metpx-sr3c (3.23.06) unstable; urgency=medium
 
   * default topicPrefix is v03, not v03.post 
   * #113 v03 message format change "integrity" to "identity"
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 09 May 2023 16:43:58 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 09 May 2023 16:43:58 -0400
 
 metpx-sr3c (3.23.05) unstable; urgency=medium
 
@@ -93,7 +93,7 @@ metpx-sr3c (3.23.05) unstable; urgency=medium
   * improvement #107 added "show" support.
   * posting with an empty relPath is actually valid.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 25 Apr 2023 15:26:21 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 25 Apr 2023 15:26:21 -0400
 
 metpx-sr3c (3.23.04p1) unstable; urgency=medium
 
@@ -105,14 +105,14 @@ metpx-sr3c (3.23.04p1) unstable; urgency=medium
   * clean up some compiler warnings.
   * posting outside of the given baseDir is an error.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 13 Apr 2023 16:20:12 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 13 Apr 2023 16:20:12 -0400
 
 metpx-sr3c (3.23.04) unstable; urgency=medium
 
   * removing debug prints.
   * more work making relPaths relative in all situations. 
 
- -- Peter <peter@bsqt.homeip.net>  Fri, 31 Mar 2023 09:06:46 -0400
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Fri, 31 Mar 2023 09:06:46 -0400
 
 metpx-sr3c (3.23.03p1) unstable; urgency=medium
 
@@ -121,14 +121,14 @@ metpx-sr3c (3.23.03p1) unstable; urgency=medium
   * test case: test_shim_mirror_strip_slash (baseURL=/ and strip)
   * remove leading slash from relPath. 
 
- -- Peter <peter@bsqt.homeip.net>  Sun, 26 Mar 2023 02:08:31 -0400
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Sun, 26 Mar 2023 02:08:31 -0400
 
 metpx-sr3c (3.23.03) unstable; urgency=medium
 
   * enhancement: adding support for metrics. ( https://github.com/MetPX/sarracenia/issues/614 )
   * testing: adding explicit absolute links to test_shim_copy
 
- -- Peter <peter@bsqt.homeip.net>  Sun, 12 Mar 2023 23:17:55 -0400
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Sun, 12 Mar 2023 23:17:55 -0400
 
 metpx-sr3c (3.23.02) unstable; urgency=medium
 
@@ -139,13 +139,13 @@ metpx-sr3c (3.23.02) unstable; urgency=medium
   * bugfix for problem with accept/reject mapping of renames. 
   * add self-test support for testing installed version.
 
- -- Peter <peter@bsqt.homeip.net>  Sun, 29 Jan 2023 09:02:55 -0500
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Sun, 29 Jan 2023 09:02:55 -0500
 
 metpx-sr3c (3.23.01p3) unstable; urgency=medium
 
   * added realpathAdjust integer option 
 
- -- Peter <peter@bsqt.homeip.net>  Sat, 28 Jan 2023 20:00:14 -0500
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Sat, 28 Jan 2023 20:00:14 -0500
 
 metpx-sr3c (3.23.01p2) unstable; urgency=medium
 
@@ -153,13 +153,13 @@ metpx-sr3c (3.23.01p2) unstable; urgency=medium
   * set argument parsing improved (now replaced, unless + prefix.)
   * added env var BROKER and EXCHANGE for CI/CD tests.
 
- -- Peter <peter@bsqt.homeip.net>  Thu, 26 Jan 2023 22:02:06 -0500
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Thu, 26 Jan 2023 22:02:06 -0500
 
 metpx-sr3c (3.23.01p1) unstable; urgency=medium
 
   * adding directory (mkdir, rmdir) event support  #104
 
- -- Peter <peter@bsqt.homeip.net>  Wed, 11 Jan 2023 13:50:21 -0500
+ -- Peter <peter.silva@ssc-spc.gc.ca>  Wed, 11 Jan 2023 13:50:21 -0500
 
 metpx-sr3c (3.23.01) unstable; urgency=medium
 
@@ -175,7 +175,7 @@ metpx-sr3c (3.23.01) unstable; urgency=medium
   * new default: when post_baseUrl use file:/... use /... to set post_baseDir.
   * when SR_SHIMDEBUG is set, it automatically turns on logLevel Debug.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 19 Dec 2022 22:44:00 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 19 Dec 2022 22:44:00 -0500
 
 metpx-sr3c (3.22.12p1) unstable; urgency=medium
 
@@ -183,7 +183,7 @@ metpx-sr3c (3.22.12p1) unstable; urgency=medium
   * fix coredump on specification of unknown checksum algorithm
   * README updated (was unchanged from v2.)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 06 Dec 2022 13:18:37 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 06 Dec 2022 13:18:37 -0500
 
 metpx-sr3c (3.22.12) unstable; urgency=medium
 
@@ -191,13 +191,13 @@ metpx-sr3c (3.22.12) unstable; urgency=medium
   * fix: #68 wgrib2 will not post (via libsrshim.) (regression in 3.22.07 now fixed.)
   * now only post once for rename case. add v2compatRenameDoublePost support
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 02 Dec 2022 15:17:53 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 02 Dec 2022 15:17:53 -0500
 
 metpx-sr3c (3.22.11) unstable; urgency=medium
 
   * fix for #103
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 17 Nov 2022 19:28:34 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 17 Nov 2022 19:28:34 -0500
 
 metpx-sr3c (3.22.09p2) unstable; urgency=medium
 
@@ -207,7 +207,7 @@ metpx-sr3c (3.22.09p2) unstable; urgency=medium
   * packaging improvements (separate devel package) 
   * fixes for #100, and #101 HPC mirroring symlink processing.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 21 Sep 2022 14:32:10 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 21 Sep 2022 14:32:10 -0400
 
 sr3c (3.22.07) unstable; urgency=medium
 
@@ -225,7 +225,7 @@ sr3c (3.22.07) unstable; urgency=medium
   * fix for #96 problem with cpost hanging on permission issues, have it report & recover better
   * adding understanding of sr3 option names in addition to v2 ones (compatibility with v3 configs)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 14 Oct 2020 13:36:47 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 14 Oct 2020 13:36:47 -0400
 
 sr3c (3.21.01a3) unstable; urgency=medium
 
@@ -233,7 +233,7 @@ sr3c (3.21.01a3) unstable; urgency=medium
   * fix for #93 missing symlinkat(2)
   * fix usage printing had fqdn and action inverted.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 14 Oct 2020 13:36:47 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 14 Oct 2020 13:36:47 -0400
 
 
 sarrac (2.20.07) stable; urgency=medium
@@ -241,7 +241,7 @@ sarrac (2.20.07) stable; urgency=medium
   * fix for coredump when a path is set to a non-existe environment variable.
   * statehost is now a boolean, as per sr_subscribe man page (core dumped before.)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 20 Jul 2020 12:05:15 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 20 Jul 2020 12:05:15 -0400
 
 sarrac (2.20.05) unstable; urgency=medium
 
@@ -253,7 +253,7 @@ sarrac (2.20.05) unstable; urgency=medium
   * added post_rate_limit ( #90 )
   * complain when invalid events specified #84.
 
- -- peter <peter@bsqt.homeip.net>  Fri, 24 Apr 2020 21:34:03 -0400
+ -- peter <peter.silva@ssc-spc.gc.ca>  Fri, 24 Apr 2020 21:34:03 -0400
 
 sarrac (2.20.02b3) unstable; urgency=medium
 
@@ -262,7 +262,7 @@ sarrac (2.20.02b3) unstable; urgency=medium
   * change AMQP message content-type fro text/plain to application/json for
     v03 messages (user feedback.)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 24 Feb 2020 11:59:19 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 24 Feb 2020 11:59:19 -0500
 
 sarrac (2.19.12b6) unstable; urgency=medium
 
@@ -270,7 +270,7 @@ sarrac (2.19.12b6) unstable; urgency=medium
   * issue #87 clean up instance files after one-shot call.
   * issue #88 do not post clearly corrupt messages.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 26 Dec 2019 23:26:34 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 26 Dec 2019 23:26:34 -0500
 
 sarrac (2.19.12b5) unstable; urgency=medium
 
@@ -279,20 +279,20 @@ sarrac (2.19.12b5) unstable; urgency=medium
   * when a message is corrupted, disconnect and reconnect. 
   * Issue #85 when restarting a component if it wasn't running before, it would not restart. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 20 Dec 2019 21:46:32 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 20 Dec 2019 21:46:32 -0500
 
 sarrac (2.19.12b4) unstable; urgency=medium
 
   * more fix for #83, added attrib event. 
   * dependencies were perhaps broken in b3?
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 18 Dec 2019 09:26:17 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 18 Dec 2019 09:26:17 -0500
 
 sarrac (2.19.12b3) unstable; urgency=medium
 
   * fix: #83 for RCM use case 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 17 Dec 2019 23:21:02 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 17 Dec 2019 23:21:02 -0500
 
 sarrac (2.19.12b2) unstable; urgency=medium
 
@@ -300,7 +300,7 @@ sarrac (2.19.12b2) unstable; urgency=medium
   * fix: #80 systematic cleanup for problem in #76. minimizing overall risk.
   * improved debian packaging dependencies.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sun, 15 Dec 2019 00:28:37 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sun, 15 Dec 2019 00:28:37 -0500
 
 sarrac (2.19.11b2) unstable; urgency=medium
 
@@ -308,7 +308,7 @@ sarrac (2.19.11b2) unstable; urgency=medium
   * new: rpm spec files for Suse and Redhat
   * fix: #78 x-expires mispelled, queues never expired.
 
- -- Peter Silva <peter@idefix>  Tue, 19 Nov 2019 15:39:56 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 19 Nov 2019 15:39:56 -0500
 
 sarrac (2.19.11b1) unstable; urgency=medium
 
@@ -316,14 +316,14 @@ sarrac (2.19.11b1) unstable; urgency=medium
   * fix: #67 post_exchange_suffix was not working.
   * new: printing hostname in options. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 31 Oct 2019 22:04:30 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 31 Oct 2019 22:04:30 -0400
 
 sarrac (2.19.10b1) unstable; urgency=medium
 
   * fix: dependencies should be on metpx-sarracenia, without python3- being mentioned. 
   * fix: usage string, removed reference to *parts*, only *blocksize*
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 01 Oct 2019 09:21:54 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 01 Oct 2019 09:21:54 -0400
 
 sarrac (2.19.08b1) unstable; urgency=medium
 
@@ -333,7 +333,7 @@ sarrac (2.19.08b1) unstable; urgency=medium
   * increased max message size from 2K to 1MB to allow v03 embedding.
   * note: v03 embedding not yet supported.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 08 Aug 2019 23:12:27 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 08 Aug 2019 23:12:27 -0400
 
 sarrac (2.19.07b2) unstable; urgency=medium
 
@@ -344,19 +344,19 @@ sarrac (2.19.07b2) unstable; urgency=medium
   * noticed a missing comma in json output (not v03 related.)
   * added option to omit libjson (documented in Makefile) to avoid dependency. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 25 Jul 2019 20:48:36 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 25 Jul 2019 20:48:36 -0400
 
 sarrac (2.19.07b1) unstable; urgency=medium
 
   * bugfix #39, add v03 posting (only, cannot parse)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 22 Jul 2019 09:05:36 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 22 Jul 2019 09:05:36 -0400
 
 sarrac (2.19.06b3) unstable; urgency=medium
 
   * bugfix: issue #61 - support for vip option. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 18 Jun 2019 01:43:10 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 18 Jun 2019 01:43:10 -0400
 
 sarrac (2.19.06b2) unstable; urgency=medium
 
@@ -366,7 +366,7 @@ sarrac (2.19.06b2) unstable; urgency=medium
   * bugfix: issue #35 - stops publishing.. the #57 and #69 fixes fix this.
   * cosmetic: issue #47 reformatted source to respect kernel C style guide.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 13 Jun 2019 00:54:46 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 13 Jun 2019 00:54:46 -0400
 
 sarrac (2.19.06b1) unstable; urgency=medium
 
@@ -377,14 +377,14 @@ sarrac (2.19.06b1) unstable; urgency=medium
   * new:  issue #44 added checksum caching support.
   * new:  issue #52 added log_reject to print log messages when rejecting messages.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 05 Jun 2019 23:07:37 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 05 Jun 2019 23:07:37 -0400
 
 sarrac (2.19.05b1ubuntu2) unstable; urgency=medium
 
   * bugfix: issue#29 adding utf8 check to avoid posting corrupted messages.  (msaraga!)
   * new:    issue#39 logging refactored to match python implementation (msaraga)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 16 May 2019 21:23:09 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 16 May 2019 21:23:09 -0400
 
 sarrac (2.19.03b5ubuntu1) unstable; urgency=medium
 
@@ -393,7 +393,7 @@ sarrac (2.19.03b5ubuntu1) unstable; urgency=medium
   * new:    additional documentation, support for doxygen.
   * new:    added support for suppress_duplicates_basis option, as per python. (from Michael!)
 
- -- Peter Silva <peter@idefix>  Fri, 29 Mar 2019 16:41:30 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 29 Mar 2019 16:41:30 -0400
 
 sarrac (2.19.02b2) unstable; urgency=medium
 
@@ -402,7 +402,7 @@ sarrac (2.19.02b2) unstable; urgency=medium
   * bugfix: crash if host has no fully qualified domain name. (some vm's and containers)
   * bugfix: broker url with port number was incorrectly parsed.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 26 Feb 2019 06:47:46 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 26 Feb 2019 06:47:46 -0500
 
 sarrac (2.18.12b4) unstable; urgency=medium
 
@@ -410,14 +410,14 @@ sarrac (2.18.12b4) unstable; urgency=medium
   * libsrshim: exit processing now posts files if they are different from last post.
   * libsrshim: if config is unusable, print an explicit message that library is disabled.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 15 Dec 2018 12:26:46 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 15 Dec 2018 12:26:46 -0500
 
 sarrac (2.18.12b3) unstable; urgency=medium
 
   * libsrshim: changed "srshim" to "shim" for progname (so messages are tagged sr_shim)
   * libsrshim: fail-open: fixes to avoid crashing on bad configs.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 06 Dec 2018 00:40:54 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 06 Dec 2018 00:40:54 -0500
 
 sarrac (2.18.12b2) unstable; urgency=medium
 
@@ -426,7 +426,7 @@ sarrac (2.18.12b2) unstable; urgency=medium
   * libsrshim: some optimizations.
   * libsrshim: fix to avoid segfault when broker connection fails.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 05 Dec 2018 18:12:25 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 05 Dec 2018 18:12:25 -0500
 
 sarrac (2.18.12b1) unstable; urgency=medium
 
@@ -441,13 +441,13 @@ sarrac (2.18.12b1) unstable; urgency=medium
   * 
   * 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 03 Dec 2018 17:48:19 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 03 Dec 2018 17:48:19 -0500
 
 sarrac (2.18.11b5) unstable; urgency=medium
 
   * change default checksum to md5sum ('d') to humour Eric.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 27 Nov 2018 14:15:17 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 27 Nov 2018 14:15:17 -0500
 
 sarrac (2.18.11b4) unstable; urgency=medium
 
@@ -460,21 +460,21 @@ sarrac (2.18.11b4) unstable; urgency=medium
   * some messages removed to remove hard-coded *cpost* strings
   * error messages now say *sr_shim* instead of sr_cpost.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 24 Nov 2018 21:07:39 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 24 Nov 2018 21:07:39 -0500
 
 sarrac (2.18.10b2) unstable; urgency=medium
 
   * added support for z, checksum algorithm. 
   * changed some error handling when there are problems calculating checksums.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 31 Oct 2018 16:37:33 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 31 Oct 2018 16:37:33 -0400
 
 sarrac (2.18.10b1) unstable; urgency=medium
 
   * removing useless debug/FIXME messages 
   * compiled with intel compiler, added -Wcheck, got rid of all warnings.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 05 Oct 2018 18:07:48 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 05 Oct 2018 18:07:48 -0400
 
 sarrac (2.18.09b4) unstable; urgency=medium
 
@@ -482,32 +482,32 @@ sarrac (2.18.09b4) unstable; urgency=medium
   * added noreturn attribute to address gcc warning for exit call
   * added ignore of files ending in ~ to config listing.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 18 Sep 2018 09:41:51 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 18 Sep 2018 09:41:51 -0400
 
 sarrac (2.18.09b1) unstable; urgency=medium
 
   * reduced default output (moved many INFO messages to DEBUG)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 17 Sep 2018 15:37:26 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 17 Sep 2018 15:37:26 -0400
 
 sarrac (2.18.08b2) unstable; urgency=medium
 
   * fixed seg fault when credentials.conf file missing.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 14 Aug 2018 14:25:50 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 14 Aug 2018 14:25:50 -0400
 
 sarrac (2.18.08b1ubuntu1) unstable; urgency=medium
 
   * fixed issue#11, programs which do not close their files, catch on process exit
   * fixed stack smashing bug when environment variable improperly set.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 09 Aug 2018 22:18:54 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 09 Aug 2018 22:18:54 -0400
 
 sarrac (2.18.07b4) unstable; urgency=medium
 
   * plugged huge memory leak in sr_cpump, and a small one in sr_cpost. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 24 Jul 2018 23:47:47 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 24 Jul 2018 23:47:47 -0400
 
 sarrac (2.18.07b3) unstable; urgency=medium
 
@@ -518,19 +518,19 @@ sarrac (2.18.07b3) unstable; urgency=medium
   * moved dup/dup/dup code to libsrshim, whic is the only place
     it should be used anyways.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 21 Jul 2018 20:09:21 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 21 Jul 2018 20:09:21 -0400
 
 sarrac (2.18.07b2) unstable; urgency=medium
 
   * change timezone of logs from UTC to local to match python implementation. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 16 Jul 2018 00:11:00 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 16 Jul 2018 00:11:00 -0400
 
 sarrac (2.18.07b1ubuntu1) unstable; urgency=medium
 
   * bugfix: sanity would restart stopped configurations
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sun, 08 Jul 2018 12:14:10 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sun, 08 Jul 2018 12:14:10 -0400
 
 sarrac (2.18.06b2) unstable; urgency=medium
 
@@ -539,26 +539,26 @@ sarrac (2.18.06b2) unstable; urgency=medium
   * implemented sanity command.
   * README updated by moving issues to github, adding ssm link.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 09 Jun 2018 22:24:52 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 09 Jun 2018 22:24:52 -0400
 
 sarrac (2.18.05b4) unstable; urgency=medium
 
   * fixed one case where connection was deferred too long (core dump.)
 
- -- peter <peter@bsqt.homeip.net>  Thu, 24 May 2018 19:53:08 -0400
+ -- peter <peter.silva@ssc-spc.gc.ca>  Thu, 24 May 2018 19:53:08 -0400
 
 sarrac (2.18.05b3) unstable; urgency=medium
 
   * added log rotation.
   * efficiency: connection broker deferred until last possible moment. 
 
- -- peter <peter@bsqt.homeip.net>  Thu, 24 May 2018 09:24:14 -0400
+ -- peter <peter.silva@ssc-spc.gc.ca>  Thu, 24 May 2018 09:24:14 -0400
 
 sarrac (2.18.04b3) unstable; urgency=medium
 
   * Split sarrac off as a separate package from python sarracenia implementation. 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 20 Apr 2018 16:24:04 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 20 Apr 2018 16:24:04 -0400
 
 sarrac (2.18.04b2) unstable; urgency=medium
 
@@ -569,7 +569,7 @@ sarrac (2.18.04b2) unstable; urgency=medium
   *         C libsrshim enforced checks on commands'status
   *         C any Python, topic and path with # encoded into %23 (as blank into %20)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 10 Apr 2018 11:17:31 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 10 Apr 2018 11:17:31 -0400
 
 sarrac (2.18.04b1) unstable; urgency=medium
 
@@ -583,7 +583,7 @@ sarrac (2.18.03b1) unstable; urgency=medium
 
   * new    realpath_filter (PY and C), realpath also named realpath_post
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 23 Mar 2018 11:57:09 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 23 Mar 2018 11:57:09 -0400
 
 sarrac (2.18.03a4) unstable; urgency=medium
 
@@ -623,7 +623,7 @@ sarrac (2.18.02a1) unstable; urgency=medium
   * bugfix: C: queue_name random seed wasn't. 
   * bugfix: C: components crash on add when SR_CONFIG_EXAMPLES is not set. Now complain and error exit.
   
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 17 Feb 2018 11:03:08 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 17 Feb 2018 11:03:08 -0500
 
 sarrac (2.18.01a5) unstable; urgency=medium
 
@@ -632,14 +632,14 @@ sarrac (2.18.01a5) unstable; urgency=medium
   * *remove* action calls cleanup. (py and C)
   * C: added prefetch option.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Sat, 27 Jan 2018 16:31:25 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Sat, 27 Jan 2018 16:31:25 -0500
 
 sarrac (2.18.01a2) unstable; urgency=medium
 
   * lkely fix included for 1 in 200 file missing in HPC mirroring.
   * C: now imports version info from python, so C version is meaningful (instead of always 1.0.0)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 05 Jan 2018 11:40:22 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 05 Jan 2018 11:40:22 -0500
 
 sarrac (2.18.01a1) unstable; urgency=medium
 
@@ -652,13 +652,13 @@ sarrac (2.18.01a1) unstable; urgency=medium
   * C: fix: segfault if credentials.conf is missing.
 
 
- -- Peter Silva <peter@bsqt.homeip.net>  Wed, 03 Jan 2018 14:27:18 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Wed, 03 Jan 2018 14:27:18 -0500
 
 sarrac (2.17.12a8) unstable; urgency=medium
 
   * c: segault in mv if there's no slashes in the source path, oops!
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 18 Dec 2017 22:48:00 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 18 Dec 2017 22:48:00 -0500
 
 sarrac (2.17.12a7) unstable; urgency=medium
 
@@ -670,7 +670,7 @@ sarrac (2.17.12a7) unstable; urgency=medium
   * removed 's' from the 'headers' option in python, to match C.
   * C: realpath only applied if an absolute path was supplied, now works for relative ones also.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 18 Dec 2017 13:15:10 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 18 Dec 2017 13:15:10 -0500
 
 sarrac (2.17.12a6) unstable; urgency=medium
 
@@ -685,13 +685,13 @@ sarrac (2.17.12a6) unstable; urgency=medium
   * C: implemented *source* option
   * C: corrected picking of "main file" for configuration name.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 12 Dec 2017 21:19:37 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 12 Dec 2017 21:19:37 -0500
 
 sarrac (2.17.12a2) unstable; urgency=medium
 
   * C: added recovery code after posting errors.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Tue, 05 Dec 2017 18:01:18 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Tue, 05 Dec 2017 18:01:18 -0500
 
 sarrac (2.17.12a1) unstable; urgency=medium
 
@@ -701,7 +701,7 @@ sarrac (2.17.12a1) unstable; urgency=medium
   * C: bugfix: pbu synonym for post_base_url, was not accepted, corrected.
   * C: fixed when renaming across file systems, it would fail, rather than copying the file.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 04 Dec 2017 17:45:52 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 04 Dec 2017 17:45:52 -0500
 
 sarrac (2.17.11a2) unstable; urgency=medium
 
@@ -711,7 +711,7 @@ sarrac (2.17.11a2) unstable; urgency=medium
   * fixed: list,get,remove,edit,log not working for other than subscribe.
   * excessive debug messaging removed.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Thu, 09 Nov 2017 17:04:06 -0500
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Thu, 09 Nov 2017 17:04:06 -0500
 
 sarrac (2.17.10a4) unstable; urgency=medium
 
@@ -719,7 +719,7 @@ sarrac (2.17.10a4) unstable; urgency=medium
   * C: loglevel now accepts words: none, critical, error, warning, info, debug. (like python version.)
   * C: logevel numbers inverted (formerly 99 was be very quiet, no 0 is quiet.)
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 30 Oct 2017 17:43:28 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 30 Oct 2017 17:43:28 -0400
 
 sarrac (2.17.10a3) unstable; urgency=medium
 
@@ -729,7 +729,7 @@ sarrac (2.17.10a3) unstable; urgency=medium
   * C: added directory support to sr_post_rename
   * C: libsrshim: added support for the truncate(2) system call.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 27 Oct 2017 17:26:21 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 27 Oct 2017 17:26:21 -0400
 
 sarrac (2.17.10a2) unstable; urgency=medium
 
@@ -740,18 +740,18 @@ sarrac (2.17.10a2) unstable; urgency=medium
   * C: added tx.select & tx.confirm (publish acknowledgements)
   * C: integrated into flow_tests.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Fri, 20 Oct 2017 13:21:57 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Fri, 20 Oct 2017 13:21:57 -0400
 
 sarrac (2.17.08a1) unstable; urgency=medium
 
   * C posting library, including sr_cpost that replicates post and watch is complete.
   * C libc shim that calls C posting library complete.
 
- -- Peter Silva <peter@bsqt.homeip.net>  Mon, 14 Aug 2017 17:54:33 -0400
+ -- Peter Silva <peter.silva@ssc-spc.gc.ca>  Mon, 14 Aug 2017 17:54:33 -0400
 
 sarrac (2.17.07a1) unstable; urgency=medium
 
   * C implementation of libsrshim, libsarra, sr_cpost, and sr_subjsondump  in C (not packaged yet.)
 
- -- peter <peter@bsqt.homeip.net>  Tue, 25 Jul 2017 20:51:34 -0400
+ -- peter <peter.silva@ssc-spc.gc.ca>  Tue, 25 Jul 2017 20:51:34 -0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-metpx-sr3c (3.24.10rc2) unstable; urgency=medium
+metpx-sr3c (3.24.10) unstable; urgency=medium
 
   * implemented remove
 

--- a/shim_copy_mirror_sftp.sh
+++ b/shim_copy_mirror_sftp.sh
@@ -137,9 +137,9 @@ cd ..
 diffs="`diff dirA.sums dirB.sums| wc -l`"
 
 cd shim_dirA
-find . -type l  | xargs ls -al >../dirA.links
+find . -type l  | xargs ls -al | cut --bytes=42- >../dirA.links
 cd ../shim_dirB
-find . -type l  | xargs ls -al >../dirB.links
+find . -type l  | xargs ls -al | cut --bytes=42- >../dirB.links
 cd ..
 
 sed 's+shim_dirB+shim_dirA+' dirB.links >dirC.links

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -119,4 +119,7 @@ echo "#test 1 remove 165 symlink in a non sub-dir"
 cd ../shim_dirC/thedir
 rm filefive
 
+echo "#test 1 rename move a file when in a linked dir.)"
+mv new_test_file middle_aged_test_file
+
 echo "#test 0 comment 160 shim copy posting end"

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -90,6 +90,12 @@ mv dirone dirthree
 echo "#test 1 link 135 symlink in a sub-dir"
 ln -sf `pwd`/dirthree/dirtwo/filefour dirthree/dirtwo/link2four
 
+echo "#test 1 link 156 symlink in a sub-dir"
+ln -sf filefour `pwd`/dirthree/dirtwo/link32_to_file4
+
+echo "#test 1 rename 156.5 symlink in a sub-dir"
+mv `pwd`/dirthree/dirtwo/link32_to_file4 `pwd`/dirthree/dirtwo/renamed_link32_to_file4
+
 echo "#test 1 sha512 create test_file with redirection."
 echo  1 >test_file
 echo "#test 1 sha512 update test_file"

--- a/sr_post.c
+++ b/sr_post.c
@@ -1068,7 +1068,7 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n)
 	}
 
 	first_user_header.key = strdup("oldname");
-	first_user_header.value = strdup(o);
+	first_user_header.value = strdup(oldname);
 
 	if (sr_c->cfg->realpathFilter) {
 		mask = sr_isMatchingPattern(sr_c->cfg, newreal);


### PR DESCRIPTION
* Added test case for https://github.com/MetPX/sarracenia/issues/1270
* Fix #169 Discovered that when realpathPost is set, rename was not posting the old name of the file with realpath applied.
* Discovered that if copy_mirror_sftp test would fail if run near the top of a minute because link comparison was including the mtime (not settable on symlinks)

