### PR TITLE
Always intercept syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ LIBCLOCATION=$(shell ldd /bin/sh | awk '/libc\.so\./ { print; }' | cut -d' ' -f3
 # On RHEL8, add -DINTERCEPT_SYSCALL to handle cases where mv calls syscall directly, instead of calling renameat2.
 # See sarrac issue #145 for more information about syscall/renameat2.
 
-CFLAGS = -DHAVE_JSONC -DSR_APPNAME=\"sr3\" -DFORCE_LIBC_REGEX=\"$(LIBCLOCATION)\" -fPIC -ftest-coverage -std=gnu99 -Wall -g -D_GNU_SOURCE $(RABBIT_INCDIR)
+CFLAGS = -DHAVE_JSONC -DSR_APPNAME=\"sr3\" -DFORCE_LIBC_REGEX=\"$(LIBCLOCATION)\" -fPIC -ftest-coverage -std=gnu99 -Wall -g -D_GNU_SOURCE $(RABBIT_INCDIR) -DINTERCEPT_SYSCALL
 
 SARRA_HEADER = sr_cache.h sr_config.h sr_consume.h sr_context.h sr_credentials.h sr_event.h sr_post.h sr_util.h sr_version.h uthash.h 
 SARRA_OBJECT = sr_post.o sr_consume.o sr_context.o sr_config.o sr_event.o sr_credentials.o sr_cache.o sr_util.o

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,9 @@ metpx-sr3c (3.24.10p1rc3) unstable; urgency=medium
     'renameat', 'rmdir', 'truncate', 'unlink', and 'unlinkat' so
     that they call "our" equivalent function that will perform the action and
     trigger a message to be posted.
+  * removed glibc version check for INTERCEPT_SYSCALL and added the definition
+    to the Makefile. We decided that we should always intercept syscall on all
+    OSes.
 
  -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Tue, 29 Oct 2024 19:47:29 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: metpx-sr3c
 Priority: optional
 Maintainer: Shared Services Canada Supercomputing <ssc.hpc-chp.spc@canada.ca>
-Build-Depends: debhelper (>=9), librabbitmq4 ( >= 0.8 ), librabbitmq-dev ( >= 0.8 ), libssl-dev, libjson-c-dev
+Build-Depends: debhelper (>=9), librabbitmq4 ( >= 0.8 ), librabbitmq-dev ( >= 0.8 ), libssl-dev, libjson-c-dev, libkeyutils-dev
 Standards-Version: 3.9.6
 Section: libs
 Homepage: https://github.com/MetPX

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -53,14 +53,6 @@ typedef sigset_t old_sigset_t;
 #include "sr_post.h"
 
 /*
-See https://github.com/MetPX/sarrac/issues/145. 
-glibc < 2.28 doesn't provide renameat2.
-*/
-#if !__GLIBC_PREREQ(2,28)
-#define INTERCEPT_SYSCALL
-#endif
-
-/*
  libsrshim - intercepts calls to libc and kernel to post files for broker.
 
 SR_SHIM_CONFIG -- environment variable to set configuration file name 


### PR DESCRIPTION
We decided that we should always intercept syscall on all OS versions. We were originally only intercepting it on RedHat 8, because the `mv` command called `renameat2` using syscall. 

But it's possible that other code on other OS versions will call other file/directory operations using syscall, so we include it everywhere now. This is possible because we now have code to pass through most other syscalls.

  