### PR TITLE
fix #179 unset env vars evaluate to empty string

### DIFF
--- a/shim_post.sh
+++ b/shim_post.sh
@@ -33,6 +33,8 @@ shim_post_minterval 10
 #shim_skip_parent_open_files
 #shim_post_once
 #shim_defer_posting_to_exit
+header home=${HOME}
+header blank=${VAR_NOT_SET}
 expire 1d
 nodupe_ttl 0
 header toto=pig

--- a/sr_config.c
+++ b/sr_config.c
@@ -675,9 +675,9 @@ static char *subarg(struct sr_config_s *sr_cfg, char *arg)
 		} else {
 			val = getenv(var);
 			if (!val) {
-				sr_log_msg(sr_cfg->logctx,LOG_ERROR, "Environment variable not set: %s\n", var);
+				//sr_log_msg(sr_cfg->logctx,LOG_ERROR, "Environment variable not set: %s\n", var);
 				*e = '}';
-				return (NULL);
+				val="";
 			}
 		}
 		strcat(d, val);


### PR DESCRIPTION
client has problem with error messages in hpc mirroring.
