### PR TITLE
remove copy_file_range (eliminates seg fault on many systems.)

### DIFF
--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1505,45 +1505,6 @@ ssize_t sendfile(int out_fd, int in_fd, off_t * offset, size_t count)
 	return (status);
 }
 
-static int copy_file_range_init_done = 0;
-typedef ssize_t (*copy_file_range_fn) (int, off_t *, int, off_t *, size_t, unsigned int);
-static copy_file_range_fn copy_file_range_fn_ptr = NULL;
-
-ssize_t copy_file_range(int fd_in, loff_t * off_in, int fd_out,
-			loff_t * off_out, size_t len, unsigned int flags)
-{
-	ssize_t status;
-	char fdpath[32];
-	char real_path[PATH_MAX + 1];
-	char *real_return;
-
-	if (!copy_file_range_init_done) {
-		setup_exit();
-		copy_file_range_fn_ptr = (copy_file_range_fn) dlsym(RTLD_NEXT, "copy_file_range");
-		copy_file_range_init_done = 1;
-	}
-	status = copy_file_range_fn_ptr(fd_in, off_in, fd_out, off_out, len, flags);
-	if (shim_disabled)
-		return (status);
-
-	snprintf(fdpath, 32, "/proc/self/fd/%d", fd_out);
-	real_return = realpath(fdpath, real_path);
-
-	sr_shimdebug_msg(1, "copy_file_range to %s\n", real_path);
-
-	if (!real_return)
-		return (status);
-	if (!strncmp(real_path, "/dev/", 5))
-		return (status);
-	if (!strncmp(real_path, "/proc/", 6))
-		return (status);
-
-	shimpost(real_path, 0);
-
-	clerror(status);
-	return (status);
-}
-
 int close(int fd)
 {
 


### PR DESCRIPTION
closes #111 

In #111, there are segmentation faults on ubuntu 24.04. I do not know why. This routine accepts file descriptors... and those descriptors need to be subsequently closed, so the file will be published when the close happens anyways. There is no need for this entry point.

When I remove this routine, stuff stops crashing. One possibility is that calculating the checksum involves reading the file again, possibly opening and re-closing it. just a guess. I hope I am not just masking the problem by removing a simple cause, but the change is good anyways.