### PR TITLE
Issue192 add hard links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test_shim_unit:
 	./sr_configtest test_post.conf 
 	./sr_utiltest 
 	./sr_cachetest
-	valgrind --show-reachable=yes --track-origins=yes `which sr3_cpost` -c local_post.conf uthash.h
+	valgrind --show-reachable=yes --track-origins=yes ./sr3_cpost -c local_post.conf uthash.h
 
 test_shim_copy_mirror:
 	-./shim_copy_mirror.sh >shim_copy_mirror.log 2>&1

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ format:
 	rm *.c~ *.h~
 
 clean:
-	rm -f *.o *.gcno *.so *.so.* *.links sr3_cpost sr_configtest sr_utiltest sr3_cpump sr_cachetest sr_cache_save.test shim_test.log call_remove 
+	rm -f *.o *.gcno *.so *.so.* *.links lovelylinkforu sr3_cpost sr_configtest sr_utiltest sr3_cpump sr_cachetest sr_cache_save.test shim_test.log call_remove 
 	rm -rf build sr_version.h metpx-sr3c_rhel7.spec dir?.links
 	-sr3 cleanup cpost/local_post
 	-sr3 cleanup subscribe/local_copy

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -942,7 +942,7 @@ static syscall_fn syscall_fn_ptr = NULL;
 int renameorlink(int olddirfd, const char *oldpath, int newdirfd,
 		 const char *newpath, int flags, int link)
 /*
-  The real implementation of all renames.
+  The real implementation of all renames (and link!)
  */
 {
 	int status;
@@ -1056,7 +1056,7 @@ int renameorlink(int olddirfd, const char *oldpath, int newdirfd,
 	if (!srshim_connect())
 		return (status);
 
-	sr_post_rename(sr_c, oreal_path, real_path);
+	sr_post_rename(sr_c, oreal_path, real_path, link);
 
 	clerror(status);
 	return (status);

--- a/shim_copy_post.sh
+++ b/shim_copy_post.sh
@@ -25,6 +25,10 @@ cp ../libsr3shim.c file_to_delete
 echo "#test 1 sha512 050 touch command"
 touch hihi
 
+echo "#test 1 hlink 050 hard link command"
+ln hoho hard_link_to_hoho
+
+
 echo "#test 1 link 060 symlink command"
 ln -s hoho haha
 

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -28,6 +28,10 @@ cp ../libsr3shim.c hoho_my_darling.txt
 
 echo "#test 1 sha512 040 cp command2"
 cp ../libsr3shim.c file_to_delete
+
+echo "#test 1 hlink 050 hard link command"
+ln hoho hard_link_to_hoho
+
 echo "#test 1 sha512 050 touch command"
 touch hihi
 

--- a/shim_post.sh
+++ b/shim_post.sh
@@ -53,6 +53,7 @@ EOT
    rm hihi 
    rm hoho 
    rm haha 
+   rm lovelylinkforu 
    rm ~/test/hoho_my_darling.txt 
    rm hoohoo
 

--- a/shim_post_run.sh
+++ b/shim_post_run.sh
@@ -27,6 +27,9 @@ rmdir sub_dir2
 echo "#test 1 sha512 070 cp command"
 cp libsr3shim.c ~/test/hoho_my_darling.txt
 
+echo "#test 1 hlink 070 ln (hardlink) command"
+ln libsr3shim.c  lovelylinkforu
+
 echo "#test 1 sha512 080 touch command"
 touch hihi
 
@@ -36,8 +39,9 @@ ln -s hoho haha
 echo "#test 1 rename 100 moving a symlink"
 mv haha hihi
 
-echo "#test 1 rename 110 hardlink to a symlink"
+echo "#test 1 hlink 110 hardlink to a symlink"
 ln hihi hoohoo
+
 echo "#test 1 rename 120 moving a file. "
 mv ~/test/hoho_my_darling.txt ~/test/hoho2.log
 echo "#test 1 remove 130 removing a file. "

--- a/sr3_cpost.c
+++ b/sr3_cpost.c
@@ -476,14 +476,14 @@ int dir_stack_check4events(struct sr_context *sr_c)
 							sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG,
 								   "ok invoking rename ofn=%s %s\n",
 								   on->ofn, fn);
-							sr_post_rename(sr_c, on->ofn, fn);
+							sr_post_rename(sr_c, on->ofn, fn, false);
 							free(on->ofn);
 						} else {
 							sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG,
 								   "ok invoking rename %s nfn=%s\n",
 								   fn, on->nfn);
 				                        rename_single_event=0;
-							sr_post_rename(sr_c, fn, on->nfn);
+							sr_post_rename(sr_c, fn, on->nfn, false);
 							free(on->nfn);
 						}
 						if (prevon)

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -628,7 +628,7 @@ char *sr_message_2log(struct sr_message_s *m)
 		sprintf(strchr(b, '\0'), ", \"identity\":{ %s } ", ci);
 	}
 
-	if ((m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {
+	if ((m->sum[0] != 'l') && (m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {
 		sprintf(strchr(b, '\0'), ", \"mtime\":\"%s\", \"atime\":\"%s\"", m->mtime,
 			m->atime);
 
@@ -647,6 +647,8 @@ char *sr_message_2log(struct sr_message_s *m)
 	for (struct sr_header_s * h = m->user_headers; h; h = h->next) {
 		if (!strcmp(h->key, "oldname")) {
 			rename = h->value;
+		} else if (!strcmp(h->key, "hlink")) {
+			continue;
 		} else {
 			sprintf(strchr(b, '\0'), ", \"%s\":\"%s\"", h->key, h->value);
 		}
@@ -658,6 +660,8 @@ char *sr_message_2log(struct sr_message_s *m)
 		} else {
 			sprintf(strchr(b, '\0'), "}");
 		}
+	} else if (m->sum[0] == 'l') {
+		sprintf(strchr(b, '\0'), ", \"fileOp\" : { \"hlink\":\"%s\" }", m->link);
 	} else if (m->sum[0] == 'R') {
 		sprintf(strchr(b, '\0'), ", \"fileOp\" : { \"remove\":\"\"");
 		if (rename) {

--- a/sr_post.c
+++ b/sr_post.c
@@ -288,7 +288,7 @@ void v03encode(char *message_body, struct sr_context *sr_c, struct sr_message_s 
 	if (m->source[0])
 		v03amqp_header_add(sr_c->cfg->logctx, &c, "source", m->source);
 
-	if ((m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'm') && (m->sum[0] != 'r')) {
+	if ((m->sum[0] != 'l') && (m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'm') && (m->sum[0] != 'r')) {
 		if (m->parts_s != '1') {
 			status = sprintf(c,
 					 ",%s\"blocks\" : { \"method\": \"%s\", \"size\" : "
@@ -311,17 +311,20 @@ void v03encode(char *message_body, struct sr_context *sr_c, struct sr_message_s 
 			v03amqp_header_add(sr_c->cfg->logctx, &c, "mtime", v03time(sr_c->cfg->logctx,m->mtime));
 		}
 	}
-	if ((m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {
+	if ((m->sum[0] != 'l') && (m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {
 		if (m->mode > 0) {
 			sprintf(smallbuf, "%03o", m->mode);
 			v03amqp_header_add(sr_c->cfg->logctx, &c, "mode", smallbuf);
 		}
 	}
 
+        sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "figuring out fileop sum[0]=%c, link=%s\n", m->sum[0], m->link );
 	rename_value = NULL;
 	for (uh = m->user_headers; uh; uh = uh->next) {
 		if (!strcmp(uh->key, "oldname")) {
 			rename_value = uh->value;
+		} else if (!strcmp(uh->key, "hlink")) {
+			continue;
 		} else {
 			v03amqp_header_add(sr_c->cfg->logctx, &c, uh->key, uh->value);
 		}
@@ -334,6 +337,9 @@ void v03encode(char *message_body, struct sr_context *sr_c, struct sr_message_s 
 		} else {
 			status = sprintf(c, ", \"fileOp\": { \"link\":\"%s\" }", m->link);
 		}
+		c += status;
+	} else if (m->sum[0] == 'l') {
+		status = sprintf(c, ", \"fileOp\": { \"hlink\":\"%s\" }", m->link);
 		c += status;
 	} else if (m->sum[0] == 'R') {
 		if (rename_value) {
@@ -828,6 +834,13 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 
 	m->user_headers = sr_c->cfg->user_headers;
 
+	char *hlink = NULL;
+	for (struct sr_header_s *uh = sr_c->cfg->user_headers; uh; uh=uh->next ) {
+             if (!strcmp(uh->key,"hlink")) 
+		     hlink=strdup(uh->value);
+	}
+	sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post found hlink: %s\n", hlink );
+
 	m->sum[0] = sr_c->cfg->sumalgo;
 	if (sr_c->cfg->sumalgo == 'z') {
 		m->sum[1] = ',';
@@ -845,7 +858,8 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 		m->sum[0] = rmdir_in_progress ? 'r' : 'R';
 		rmdir_in_progress = 0;
 
-	} else if (S_ISLNK(sb->st_mode)) {
+	} else if (S_ISLNK(sb->st_mode) || hlink) {
+	        sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post doing hlink: %s\n", hlink );
 		if (!((sr_c->cfg->events) & SR_EVENT_LINK))
 			return (0);	// not posting links...
 
@@ -853,11 +867,19 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 		strcpy(m->mtime, sr_time2str(&(sb->st_mtim)));
 		m->mode = sb->st_mode & 07777;
 
-		m->sum[0] = 'L';
+		if (hlink) {
+			m->sum[0] = 'l';
+		} else {
+			m->sum[0] = 'L';
+		}
 		linkstr[0] = '\0';
-		linklen = readlink(fn, linkstr, PATH_MAX);
-		linkstr[linklen] = '\0';
-		strcpy(m->link, linkstr);
+		if (hlink) {
+			strcpy(m->link,hlink);
+		} else {
+			linklen = readlink(fn, linkstr, PATH_MAX);
+			linkstr[linklen] = '\0';
+			strcpy(m->link, linkstr);
+		}
 
 	} else if (S_ISDIR(sb->st_mode)) {
 		if (!((sr_c->cfg->events) & SR_EVENT_MKDIR))
@@ -869,6 +891,7 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 		m->sum[0] = 'm';
 	} else if (S_ISREG(sb->st_mode)) {	/* regular files, add mode and determine block parameters */
 
+	        sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post regular: \n" );
 		if (!((sr_c->cfg->events) & (SR_EVENT_CREATE | SR_EVENT_MODIFY)))
 			return (0);
 
@@ -963,7 +986,7 @@ void sr_post(struct sr_context *sr_c, const char *pathspec, struct stat *sb)
 
 }
 
-void sr_post_rename(struct sr_context *sr_c, const char *oldname, const char *newname);
+void sr_post_rename(struct sr_context *sr_c, const char *oldname, const char *newname, const bool link);
 
 void sr_post_rename_dir(struct sr_context *sr_c, const char *oldname, const char *newname)
 {
@@ -994,7 +1017,7 @@ void sr_post_rename_dir(struct sr_context *sr_c, const char *oldname, const char
 			continue;
 		strcat(oldpath, e->d_name);
 		strcat(newpath, e->d_name);
-		sr_post_rename(sr_c, oldpath, newpath);
+		sr_post_rename(sr_c, oldpath, newpath, 0);
 
 		oldpath[oldlen] = '\0';
 		newpath[newlen] = '\0';
@@ -1003,7 +1026,7 @@ void sr_post_rename_dir(struct sr_context *sr_c, const char *oldname, const char
 	closedir(dir);
 }
 
-void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n)
+void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n, const bool link)
 /*
    assume actual rename is completed, so newname exists.
  */
@@ -1035,7 +1058,6 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n)
 		realpath_adjust(sr_c->cfg->logctx, oldname, oldreal, sr_c->cfg->realpathAdjust);
 		sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "applying realpath to old: %s -> %s\n", oldname, oldreal);
 
-		//realpath(n, newreal);
 		realpath_adjust(sr_c->cfg->logctx, newname, newreal, sr_c->cfg->realpathAdjust);
 		sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "applying realpath to new: %s -> %s\n", newname, newreal);
 	}
@@ -1054,11 +1076,6 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n)
 			   newname, es);
 		return;
 	}
-	/* 2023/01/20 - now that dirs have posts, just handle dirs normally.
-	   if (S_ISDIR(sb.st_mode)) {
-	   sr_post_rename_dir(sr_c, oldname, newname);
-	   }
-	 */
 
 	first_user_header.next = sr_c->cfg->user_headers;
 	sr_c->cfg->user_headers = &first_user_header;
@@ -1091,7 +1108,11 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n)
 		free(first_user_header.value);
 	}
 
-	first_user_header.key = strdup("oldname");
+	if (link) {
+	     first_user_header.key = strdup("hlink");
+	} else {
+	     first_user_header.key = strdup("oldname");
+        }
 	first_user_header.value = strdup(oldname);
 
 	if (sr_c->cfg->realpathFilter) {

--- a/sr_post.h
+++ b/sr_post.h
@@ -68,7 +68,7 @@ void sr_post(struct sr_context *sr_c, const char *fn, struct stat *sb);
 
  */
 
-void sr_post_rename(struct sr_context *sr_c, const char *oldname, const char *newname);
+void sr_post_rename(struct sr_context *sr_c, const char *oldname, const char *newname, bool link);
 /* 
    post rename results in a post for removal of the old name, and creation of the new name.
 

--- a/sr_util.c
+++ b/sr_util.c
@@ -658,6 +658,7 @@ int sr_get_sumhashlen(char algo)
 
 	case 'p':
 	case 's':
+	case 'l':
 	case 'L':
 	case 'R':
 		return (SHA512_DIGEST_LENGTH + 1);
@@ -681,6 +682,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
     'd' - md5sum of block.
     'n' - md5sum of filename (fn).
     'L' - now sha512 sum of link value.
+    'l' - hard link.
     'm' - mkdir
     'p' - md5sum of filename (fn) + partstr.
     'r' - rmdir
@@ -809,6 +811,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		sr_hash2sumstr(sumstrptr, sumhash);
 		break;
 
+	case 'l':
 	case 'L':		// symlink case
 		just_the_name = linkstr;
 		ctx = EVP_MD_CTX_create();


### PR DESCRIPTION
close #192 

libsr3shim and sr_post.c now generate proper v03 hardlink messages ( with "fileOp": { "hlink": "link value" }  fields. } 
and v02 sum="l,sum" hlink="...." fields.   When I added hardlinks to the test suites, I saw the current python has a crasher bug in an display message. so all the tests here will fail until both fixes are merged.   really only tested with v03
format as all deployments are in that.

In my testing the commits here, using the https://github.com/MetPX/sarracenia/tree/issue1363_hardlinks branch for the python, it works.


