### PR TITLE
file names with spaces were url encoded. wrongly.

### DIFF
--- a/sr_post.c
+++ b/sr_post.c
@@ -724,7 +724,9 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
             d++;
         }
 
+	// this quoting is for relPath is ill-advised. 
 	while (*d) {
+		/*
 		if (*d == ' ') {
 			*c++ = '%';
 			*c++ = '2';
@@ -736,7 +738,8 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 				*c++ = '3';
 			} else
 				*c++ = *d;
-		}
+		} */
+		*c++ = *d;
 		d++;
 	}
 	*c = '\0';


### PR DESCRIPTION
I was playing with hpc-mirroring use case and noticed this problem.  C and python implementations 

I see the python does not do this, and I noticed it broke mirroring when files on the source tree had spaces the C would post with %20, which confused the heck out of the python.  

I first tried adding %20 encoding on the python side... but it was a spiral downward... backed up.. and decided removal of the url encoding was the better ... um... *path.* yeah. that's the issue... you don't need url encoding if your value is a path (a file name) but you do if the value is part of a url for some protocols like http.  So at some point will have to figure out places to add url encoding.

for now, for file: urls', the answer is ... never.
