### PR TITLE
wip for #196 but also fixing #198

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+metpx-sr3c (3.25.03rc1) UNRELEASED; urgency=medium
+
+  * fix #199 not posting when regex does not match
+  * fix #198 rm -rf make file remove events instead of directory ones.
+  * fix rmdir processing re-written, with API change to produce rmdir events
+    properly.
+  * fix shimdebug messaging priorities check was wrong.
+  * work on #196... core dumps occuring in process cleanup. not fixed.
+  
+ -- peter <peter@bsqt.homeip.net>  Fri, 14 Mar 2025 08:48:03 -0400
+
 metpx-sr3c (3.24.12) unstable; urgency=medium
 
   * fix #192 libsr3shim does not produce hard link events.

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1347,24 +1347,26 @@ void exit_cleanup_posts()
 		if (!srshim_connect())
 			continue;
 
-		sr_shimdebug_msg(8, "exit_cleanup_post, looking at: %s\n",
-				 (*remembered_filenames)[i].name);
-		statres = lstat((*remembered_filenames)[i].name, &sb);
+		char *name = (*remembered_filenames)[i].name; 
+
+		sr_shimdebug_msg(8, "exit_cleanup_post, looking at: %s\n", name);
+		statres = lstat(name, &sb);
+
+		sr_shimdebug_msg(8, "exit_cleanup_post, name: %s stat: %d\n", name, statres);
 
 		if (statres) {
-			sr_post(sr_c, (*remembered_filenames)[i].name, NULL);
+			sr_post(sr_c, name, NULL);
 		} else {
 			if (S_ISLNK(sb.st_mode)) {
-				sr_shimdebug_msg(8, "exit_cleanup_post reading link: %s\n",
-						 (*remembered_filenames)[i].name);
+				sr_shimdebug_msg(8, "exit_cleanup_post reading link: %s\n", name);
 				statres =
-				    readlink((*remembered_filenames)[i].name, real_path, PATH_MAX);
+				    readlink(name, real_path, PATH_MAX);
 				if (statres) {
 					real_path[statres] = '\0';
 					sr_post(sr_c, real_path, &sb);
 				}
 			}
-			sr_post(sr_c, (*remembered_filenames)[i].name, &sb);
+			sr_post(sr_c, name, &sb);
 		}
 	}
 	sr_shimdebug_msg(1, "exit_cleanup_posting closing context sr_c=%p\n", sr_c);

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -104,7 +104,7 @@ void sr_shimdebug_msg(int level, const char *format, ...)
 		clock_gettime(CLOCK_REALTIME, &ts);
 		srshim_debug_level = atoi(srdbgstr);
 		mypid = getpid();
-		fprintf(stderr, " startup ");
+		fprintf(stderr, "sr_shimdebug startup SR_SHIMDEBUG=%d\n", srshim_debug_level );
 		pid_seconds_wallclock = ts.tv_sec;
 
 	} else if (srshim_debug_level == -2)
@@ -112,11 +112,11 @@ void sr_shimdebug_msg(int level, const char *format, ...)
 
 	clock_gettime(CLOCK_REALTIME, &ts);
 
-	if (level & srshim_debug_level)
+	if ( (level & srshim_debug_level) == 0)
 		return;
 
 	fprintf(stderr, "SR_SHIMDEBUG %d %d %g ", level, mypid,
-		(ts.tv_sec + ts.tv_nsec / 1e9) - pid_seconds_wallclock);
+        	(ts.tv_sec + ts.tv_nsec / 1e9) - pid_seconds_wallclock);
 
 	va_start(ap, format);
 	vfprintf(stderr, format, ap);

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -280,7 +280,7 @@ struct filename_memory (*remembered_filenames)[] = NULL;
 int remembered_count = 0;
 int remembered_max = 0;
 
-int should_not_post(const char *fn)
+int should_not_post(const char *fn, const int rmflags)
 /*
    given the file name fn, return(1) if we should not post it, 0 otherwise.
 
@@ -353,7 +353,8 @@ int should_not_post(const char *fn)
 	(*remembered_filenames)[remembered_count].ts = ts;
 	(*remembered_filenames)[remembered_count++].name = strdup(fn);
 
-	sr_shimdebug_msg(1, "remembering post of %s (count=%d) \n", fn, remembered_count);
+	sr_shimdebug_msg(1, "remembering post of %s (count=%d) \n", 
+			fn, remembered_count );
 	return (0);
 
 }
@@ -472,7 +473,7 @@ int srshim_connect()
 	return (sr_connected);
 }
 
-void srshim_realpost(const char *path)
+void srshim_realpost(const char *path, const int rmflags)
 /*
   post using initialize sr_ context.
 
@@ -484,7 +485,7 @@ void srshim_realpost(const char *path)
 	char fn[PATH_MAX + 1];
 	char fnreal[PATH_MAX + 1];
 
-	sr_shimdebug_msg(1, "srshim_realpost 1 PATH %s src=%p\n", path, sr_c);
+	sr_shimdebug_msg(1, "srshim_realpost 1 PATH %s src=%p rmflags=%d\n", path, sr_c, rmflags);
 
 	if (!path || !sr_c)
 		return;
@@ -524,7 +525,7 @@ void srshim_realpost(const char *path)
 	}
 	sr_shimdebug_msg(1, "srshim_realpost accepted... %s now\n", fn);
 
-	if (should_not_post(fn)) {
+	if (should_not_post(fn,rmflags)) {
 		sr_shimdebug_msg(1, "srshim_realpost rejecting should_not_post... %s\n", fn);
 		return;
 	}
@@ -541,16 +542,16 @@ void srshim_realpost(const char *path)
 		sr_shimdebug_msg(1,
 				 "srshim_realpost should be really posting %s remove now sr_c=%p\n",
 				 path, sr_c);
-		sr_post(sr_c, path, NULL);
+		sr_post(sr_c, path, NULL, rmflags);
 		return;
 	}
 
 	sr_shimdebug_msg(1, "srshim_realpost 9 PATH %s\n", path);
-	sr_post(sr_c, path, &sb);
+	sr_post(sr_c, path, &sb, rmflags);
 
 }
 
-int shimpost(const char *path, int status)
+int shimpost(const char *path, int status, const int rmflags)
 {
 	char *cwd = NULL;
 	char *real_path = NULL;
@@ -569,7 +570,7 @@ int shimpost(const char *path, int status)
 
 		if (path[0] == '/') {
 			sr_shimdebug_msg(4, "absolute 1 shimpost %s, status=%d\n", path, status);
-			srshim_realpost(path);
+			srshim_realpost(path, rmflags);
 		} else {
 			cwd = get_current_dir_name();
 			real_path = (char *)malloc(strlen(cwd) + strlen(path) + 3);
@@ -579,7 +580,7 @@ int shimpost(const char *path, int status)
 			strcat(real_path, path);
 			sr_shimdebug_msg(4, "relative 2 shimpost %s status=%d\n", real_path,
 					 status);
-			srshim_realpost(real_path);
+			srshim_realpost(real_path, rmflags);
 			free(real_path);
 			free(cwd);
 		}
@@ -618,7 +619,7 @@ int truncate(const char *path, off_t length)
 	if (!strncmp(path, "/proc/", 6))
 		return (status);
         errno=0;
-	return (shimpost(path, status));
+	return (shimpost(path, status, 0));
 
 }
 
@@ -648,7 +649,7 @@ int mkdir(const char *pathname, mode_t mode)
 	if (!strncmp(pathname, "/proc/", 6))
 		return (status);
 
-	return (shimpost(pathname, status));
+	return (shimpost(pathname, status, 0));
 }
 
 static int mkdirat_init_done = 0;
@@ -677,7 +678,7 @@ int mkdirat(int dirfd, const char *pathname, mode_t mode)
 	if (!strncmp(pathname, "/proc/", 6))
 		return (status);
 
-	return (shimpost(pathname, status));
+	return (shimpost(pathname, status, 0));
 }
 
 static int rmdir_init_done = 0;
@@ -706,8 +707,7 @@ int rmdir(const char *pathname)
 	if (!strncmp(pathname, "/proc/", 6))
 		return (status);
 
-	rmdir_in_progress = 1;
-	return (shimpost(pathname, status));
+	return (shimpost(pathname, status, 2));
 }
 
 static int remove_init_done = 0;
@@ -739,7 +739,7 @@ int remove(const char *pathname)
 	if (shim_disabled)
 		return (status);
 
-	sr_shimdebug_msg(1, " remove 2 %s status=%d\n", pathname, status);	
+	sr_shimdebug_msg(1, " remove 2 %s status=%d isdir=%d\n", pathname, status, isdir);	
 
 	clerror(status);
 	if (status == -1)
@@ -750,10 +750,7 @@ int remove(const char *pathname)
 	if (!strncmp(pathname, "/proc/", 6))
 		return (status);
 
-	if (isdir) {
-		rmdir_in_progress = 1;
-	}
-	return (shimpost(pathname, status));
+	return (shimpost(pathname, status, isdir?2:1));
 }
 
 static int symlink_init_done = 0;
@@ -782,7 +779,7 @@ int symlink(const char *target, const char *linkpath)
 	if (!strncmp(linkpath, "/proc/", 6))
 		return (status);
 
-	return (shimpost(linkpath, status));
+	return (shimpost(linkpath, status, 0));
 }
 
 static int symlinkat_init_done = 0;
@@ -817,7 +814,7 @@ int symlinkat(const char *target, int dirfd, const char *linkpath)
 
 	if (dirfd == AT_FDCWD) {
 		clerror(status);
-		return (shimpost(linkpath, status));
+		return (shimpost(linkpath, status, 0));
 	}
 
 	snprintf(fdpath, 32, "/proc/self/fd/%d", dirfd);
@@ -834,7 +831,7 @@ int symlinkat(const char *target, int dirfd, const char *linkpath)
 	strcat(real_path, linkpath);
 
 	clerror(status);
-	return (shimpost(real_path, status));
+	return (shimpost(real_path, status, 0));
 
 }
 
@@ -850,6 +847,7 @@ int unlinkat(int dirfd, const char *path, int flags)
 	char fdpath[PATH_MAX + 1];
 	char real_path[PATH_MAX + 1];
 	char *real_return;
+	bool isdir = false;
 
 	sr_shimdebug_msg(1, "unlinkat %s dirfd=%i\n", path, dirfd);
 	if (!unlinkat_init_done) {
@@ -859,7 +857,13 @@ int unlinkat(int dirfd, const char *path, int flags)
 	}
 
 	stat_failed = fstatat(dirfd, path, &sb, 0);
-	sr_shimdebug_msg(1, "unlinkat %s dirfd=%i stat returned: %d\n", path, dirfd, stat_failed);
+
+	if (!stat_failed) {
+		isdir = S_ISDIR(sb.st_mode);
+	}
+
+	sr_shimdebug_msg(1, "unlinkat %s dirfd=%i stat returned: %d isdir: %d\n", 
+			path, dirfd, stat_failed, isdir);
 
 	status = unlinkat_fn_ptr(dirfd, path, flags);
 	if (shim_disabled)
@@ -868,7 +872,7 @@ int unlinkat(int dirfd, const char *path, int flags)
 		return status;
 
 	if (dirfd == AT_FDCWD)
-		return (shimpost(path, status));
+		return (shimpost(path, status, 0));
 
 	snprintf(fdpath, 32, "/proc/self/fd/%d", dirfd);
 	real_return = realpath(fdpath, real_path);
@@ -881,9 +885,9 @@ int unlinkat(int dirfd, const char *path, int flags)
 	if (!real_return)
 		return (status);
 
-	sr_shimdebug_msg(1, " unlinkat realpath %s\n", real_path);
+	sr_shimdebug_msg(1, " unlinkat realpath %s, isdir=%d\n", real_path, isdir);
 
-	return (shimpost(real_path, status));
+	return (shimpost(real_path, status, isdir?2:1));
 }
 
 static int unlink_init_done = 0;
@@ -914,7 +918,7 @@ int unlink(const char *path)
 		return (status);
 	}
 
-	return (shimpost(path, status));
+	return (shimpost(path, status, 0));
 }
 
 static int link_init_done = 0;
@@ -1223,7 +1227,7 @@ int dup3(int oldfd, int newfd, int flags)
 	// because shimpost posts when:    if (!status)
 	// we use a tmpstatus and call shimpost with status=0
 
-	shimpost(real_path, 0);
+	shimpost(real_path, 0, 0);
 
 	clerror(status);
 	return status;
@@ -1327,7 +1331,7 @@ void exit_cleanup_posts()
 
 			sr_shimdebug_msg(8, "exit_cleanup_posts posting %s\n", real_path);
 
-			shimpost(real_path, 0);
+			shimpost(real_path, 0, 0);
 		}
 		closedir(fddir);
 	}
@@ -1355,7 +1359,7 @@ void exit_cleanup_posts()
 		sr_shimdebug_msg(8, "exit_cleanup_post, name: %s stat: %d\n", name, statres);
 
 		if (statres) {
-			sr_post(sr_c, name, NULL);
+			sr_post(sr_c, name, NULL, 0);
 		} else {
 			if (S_ISLNK(sb.st_mode)) {
 				sr_shimdebug_msg(8, "exit_cleanup_post reading link: %s\n", name);
@@ -1363,10 +1367,10 @@ void exit_cleanup_posts()
 				    readlink(name, real_path, PATH_MAX);
 				if (statres) {
 					real_path[statres] = '\0';
-					sr_post(sr_c, real_path, &sb);
+					sr_post(sr_c, real_path, &sb, 0);
 				}
 			}
-			sr_post(sr_c, name, &sb);
+			sr_post(sr_c, name, &sb, 0);
 		}
 	}
 	sr_shimdebug_msg(1, "exit_cleanup_posting closing context sr_c=%p\n", sr_c);
@@ -1513,7 +1517,7 @@ ssize_t sendfile(int out_fd, int in_fd, off_t * offset, size_t count)
 	if (!strncmp(real_path, "/proc/", 6))
 		return (status);
 
-	shimpost(real_path, 0);
+	shimpost(real_path, 0, 0);
 
 	clerror(status);
 	return (status);
@@ -1593,7 +1597,7 @@ int close(int fd)
 		return (status);
 	}
 
-	return shimpost(real_path, status);
+	return shimpost(real_path, status, 0);
 }
 
 static int fclose_init_done = 0;
@@ -1681,7 +1685,7 @@ int fclose(FILE * f)
 	sr_shimdebug_msg(2, "fclose %p %s status=%d\n", f, real_path, status);
 
 	errno=saved_errno;
-	return shimpost(real_path, status);
+	return shimpost(real_path, status, 0);
 }
 
 static int fopen_init_done = 0;

--- a/shim_post_run.sh
+++ b/shim_post_run.sh
@@ -20,7 +20,7 @@ mkdir sub_dir1
 echo "#test 1 rename 050 rename directory"
 mv sub_dir1 sub_dir2
 
-echo "#test 1 rmdir 060 remove directory"
+echo "#test 1 remove 060 remove directory"
 rmdir sub_dir2
 
 
@@ -80,7 +80,7 @@ cp "dirone/filetwo copy with spaces in the name" "dirone/second spaced file"
 
 echo "#test 1 rename 190 renaming subdirs should cause file rename events."
 mv dirone dirthree
-echo "#test 5,1 remove,rmdir 200 removing a whole tree events."
+echo "#test 6 remove 200 removing a whole tree events."
 rm -rf dirthree
 echo "#test 2 remove 210 removing two files"
 rm hoho hoohoo
@@ -88,7 +88,7 @@ rm hoho hoohoo
 echo "#test 1 directory 220 make directory for remove test"
 mkdir dir_to_remove1
 
-echo "#test 1 rmdir 230 remove directory using remove"
+echo "#test 1 remove 230 remove directory using remove"
 ./call_remove dir_to_remove1
 
 echo "#test 1 sha512 240 make file for remove test"

--- a/shim_post_run.sh
+++ b/shim_post_run.sh
@@ -80,7 +80,7 @@ cp "dirone/filetwo copy with spaces in the name" "dirone/second spaced file"
 
 echo "#test 1 rename 190 renaming subdirs should cause file rename events."
 mv dirone dirthree
-echo "#test 6 remove 200 removing a whole tree events."
+echo "#test 5,1 remove,rmdir 200 removing a whole tree events."
 rm -rf dirthree
 echo "#test 2 remove 210 removing two files"
 rm hoho hoohoo

--- a/shim_post_run.sh
+++ b/shim_post_run.sh
@@ -80,7 +80,7 @@ cp "dirone/filetwo copy with spaces in the name" "dirone/second spaced file"
 
 echo "#test 1 rename 190 renaming subdirs should cause file rename events."
 mv dirone dirthree
-echo "#test 4 remove 200 removing a whole tree events."
+echo "#test 6 remove 200 removing a whole tree events."
 rm -rf dirthree
 echo "#test 2 remove 210 removing two files"
 rm hoho hoohoo

--- a/sr3_cpost.c
+++ b/sr3_cpost.c
@@ -283,7 +283,7 @@ void do1file(struct sr_context *sr_c, char *fn)
 	}
 
 	if (lstat(fn, &sb) < 0) {
-		sr_post(sr_c, fn, NULL);	/* post file remove */
+		sr_post(sr_c, fn, NULL, 1);	/* post file remove */
 		return;
 	}
 
@@ -294,7 +294,7 @@ void do1file(struct sr_context *sr_c, char *fn)
 				   fn, (sr_c->cfg->follow_symlinks) ? "on" : "off");
 
 		//if (ts_newer( sb.st_mtim, latest_min_mtim ))
-		sr_post(sr_c, fn, &sb);	// post the link itself.
+		sr_post(sr_c, fn, &sb, 0);	// post the link itself.
 
 		/* FIXME:  INOT  - necessary? I think symlinks can be skipped?
 		 */
@@ -311,7 +311,7 @@ void do1file(struct sr_context *sr_c, char *fn)
 
 	} else if (S_ISDIR(sb.st_mode))	// process a directory.
 	{
-		sr_post(sr_c, fn, &sb);	/* post mkdir */
+		sr_post(sr_c, fn, &sb, 0);	/* post mkdir */
 
 		if (sr_c->cfg->debug)
 			sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG,
@@ -367,7 +367,7 @@ void do1file(struct sr_context *sr_c, char *fn)
 
 	} else {
 		//if (ts_newer( sb.st_mtim, latest_min_mtim )) 
-		sr_post(sr_c, fn, &sb);	// process a file
+		sr_post(sr_c, fn, &sb, 0);	// process a file
 	}
 
 }

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -677,7 +677,7 @@ char *sr_message_2log(struct sr_message_s *m)
 			sprintf(strchr(b, '\0'), "}");
 		}
 	} else if (m->sum[0] == 'r') {
-		sprintf(strchr(b, '\0'), ", \"fileOp\" : { \"rmdir\":\"\"");
+		sprintf(strchr(b, '\0'), ", \"fileOp\" : { \"remove\":\"\", \"directory\":\"\" ");
 		if (rename) {
 			sprintf(strchr(b, '\0'), ", \"rename\" : \"%s\" }", rename);
 		} else {

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -623,9 +623,9 @@ char *sr_message_2log(struct sr_message_s *m)
 	sprintf(b, "{ \"pubTime\":\"%s\", \"baseUrl\":\"%s\", \"relPath\":\"%s\", \"topic\":\"%s\"",
 		m->datestamp, m->url, m->relPath, m->routing_key);
 
-	if (!strchr("lLmrR", m->sum[0])) {
-	        ci = v03identity(m);
-		if (ci) sprintf(strchr(b, '\0'), ", \"identity\":{ %s } ", ci);
+	ci = v03identity(m);
+	if (ci && !strchr("mrRL", m->sum[0])) {
+		sprintf(strchr(b, '\0'), ", \"identity\":{ %s } ", ci);
 	}
 
 	if ((m->sum[0] != 'l') && (m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {

--- a/sr_consume.c
+++ b/sr_consume.c
@@ -623,9 +623,9 @@ char *sr_message_2log(struct sr_message_s *m)
 	sprintf(b, "{ \"pubTime\":\"%s\", \"baseUrl\":\"%s\", \"relPath\":\"%s\", \"topic\":\"%s\"",
 		m->datestamp, m->url, m->relPath, m->routing_key);
 
-	ci = v03identity(m);
-	if (ci && !strchr("mrRL", m->sum[0])) {
-		sprintf(strchr(b, '\0'), ", \"identity\":{ %s } ", ci);
+	if (!strchr("lLmrR", m->sum[0])) {
+	        ci = v03identity(m);
+		if (ci) sprintf(strchr(b, '\0'), ", \"identity\":{ %s } ", ci);
 	}
 
 	if ((m->sum[0] != 'l') && (m->sum[0] != 'R') && (m->sum[0] != 'L') && (m->sum[0] != 'r')) {

--- a/sr_post.c
+++ b/sr_post.c
@@ -894,7 +894,7 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 		m->sum[0] = 'm';
 	} else if (S_ISREG(sb->st_mode)) {	/* regular files, add mode and determine block parameters */
 
-	        sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post regular: \n" );
+	        sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post regular file: \n" );
 		if (!((sr_c->cfg->events) & (SR_EVENT_CREATE | SR_EVENT_MODIFY)))
 			return (0);
 

--- a/sr_post.c
+++ b/sr_post.c
@@ -937,7 +937,6 @@ struct sr_message_s *sr_file2message_seq(struct sr_context *sr_c,
 		sr_log_msg(sr_c->cfg->logctx,LOG_ERROR,
 			   "file2message_seq unable to generate %c checksum for: %s\n",
 			   m->parts_s, pathspec);
-		free(sumstr);
 		return (NULL);
 	}
 	strcpy(m->sum, sumstr);

--- a/sr_post.c
+++ b/sr_post.c
@@ -1108,7 +1108,7 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n, const
 			    && (S_ISREG(sb.st_mode) || S_ISLNK(sb.st_mode))) {
 				sr_post(sr_c, oldname, &sb, 0);
 			} else {
-				sr_post(sr_c, oldname, NULL, 0);
+				sr_post(sr_c, oldname, NULL, S_ISDIR(sb.st_mode)?2:1);
 			}
 		}
 

--- a/sr_post.c
+++ b/sr_post.c
@@ -96,8 +96,6 @@ static amqp_table_entry_t headers[HDRMAX];
 static int hdrcnt = 0;
 static int bad_hdrcnt = 0;
 
-int rmdir_in_progress = 0;
-
 static void header_reset()
 {
 	hdrcnt--;
@@ -658,7 +656,7 @@ void realpath_adjust(struct sr_log_context_s *logctx, const char *input_path, ch
 }
 
 int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
-			  struct stat *sb, struct sr_message_s *m)
+			  struct stat *sb, struct sr_message_s *m, const int rmflags)
 /*
   reading a file, initialize the message that corresponds to it. Return the number of messages to post entire file.
  */
@@ -853,13 +851,21 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 
 	if (!sb) {
 		if (!((sr_c->cfg->events) & SR_EVENT_DELETE) ||
-		    (!((sr_c->cfg->events) & SR_EVENT_RMDIR) && rmdir_in_progress)
+		    (!((sr_c->cfg->events) & SR_EVENT_RMDIR) && rmflags)
 		    ) {
-			rmdir_in_progress = 0;
 			return (0);	// not posting deletes...
 		}
-		m->sum[0] = rmdir_in_progress ? 'r' : 'R';
-		rmdir_in_progress = 0;
+		switch(rmflags) {
+                   case 2: // directory.
+			   m->sum[0] = 'r';
+			   break;
+		   case 1: // non-directory.
+			   m->sum[0] = 'R';
+			   break;
+	           default: // weirdness...
+	               sr_log_msg(sr_c->cfg->logctx,LOG_ERROR, "sr_post corrupt removal rmflags=%d\n", rmflags );
+		       m->sum[0] = 'R'; //defaulting to normal file.
+		}
 
 	} else if (S_ISLNK(sb->st_mode) || hlink) {
 	        sr_log_msg(sr_c->cfg->logctx,LOG_DEBUG, "sr_post doing hlink: %s\n", hlink );
@@ -944,7 +950,7 @@ struct sr_message_s *sr_file2message_seq(struct sr_context *sr_c,
 	return (m);
 }
 
-void sr_post(struct sr_context *sr_c, const char *pathspec, struct stat *sb)
+void sr_post(struct sr_context *sr_c, const char *pathspec, struct stat *sb, const int rmflags)
 {
 	static struct sr_message_s m;
 	int numblks;
@@ -962,7 +968,7 @@ void sr_post(struct sr_context *sr_c, const char *pathspec, struct stat *sb)
 
 	// report...
 	// FIXME: duration, consumingurl, consuminguser, statuscode?
-	numblks = sr_file2message_start(sr_c, pathspec, sb, &m);
+	numblks = sr_file2message_start(sr_c, pathspec, sb, &m, rmflags);
 	for (int blk = 0; (blk < numblks); blk++) {
 		if (sr_file2message_seq(sr_c, pathspec, blk, &m)) {
 			if (sr_c->cfg->nodupe_ttl > 0) {
@@ -1100,9 +1106,9 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n, const
 		} else {
 			if (!access(oldname, F_OK)
 			    && (S_ISREG(sb.st_mode) || S_ISLNK(sb.st_mode))) {
-				sr_post(sr_c, oldname, &sb);
+				sr_post(sr_c, oldname, &sb, 0);
 			} else {
-				sr_post(sr_c, oldname, NULL);
+				sr_post(sr_c, oldname, NULL, 0);
 			}
 		}
 
@@ -1127,7 +1133,7 @@ void sr_post_rename(struct sr_context *sr_c, const char *o, const char *n, const
 		if (sr_c->cfg->logReject)
 			sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "rejecting newname: %s\n", newname);
 	} else
-		sr_post(sr_c, newname, &sb);
+		sr_post(sr_c, newname, &sb, 0);
 
 	free(first_user_header.key);
 	free(first_user_header.value);

--- a/sr_post.h
+++ b/sr_post.h
@@ -27,11 +27,6 @@
 #include "sr_context.h"
 #include "sr_consume.h"
 
-/* 
- * um... set variable during rm' events to trigger an rmdir instead of a file unlink.
- */
-extern int rmdir_in_progress;
-
 void v03encode(char *message_body, struct sr_context *sr_c, struct sr_message_s *m);
 /* 
    fill the message body with a v03 encoded representation of the given message, in the given context.
@@ -54,7 +49,7 @@ void sr_post_message(struct sr_context *sr_c, struct sr_message_s *m);
    (posts over an existing connection.)
 */
 
-void sr_post(struct sr_context *sr_c, const char *fn, struct stat *sb);
+void sr_post(struct sr_context *sr_c, const char *fn, struct stat *sb, const int rmflags);
 /* 
    post the given file name using the established context.
    (posts over an existing connection.)
@@ -65,6 +60,11 @@ void sr_post(struct sr_context *sr_c, const char *fn, struct stat *sb);
 
    if passed sb=NULL, then the sr_post generates an 'R' (remove) message
    for the named file.
+
+   rmflags 
+   * 0 -- sb MUST not be null, this is not a remove event.
+   * 1 -- sb==NULL this is a file (non-directory) removal.
+   * 2 -- sb==NULL this is a directory removal.
 
  */
 

--- a/sr_util.c
+++ b/sr_util.c
@@ -710,6 +710,9 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	end = start + ((block_num < (block_count - (block_rem != 0))) ? block_size : block_rem);
 
+	just_the_name = rindex(fn, '/');
+	just_the_name = just_the_name ? just_the_name + 1 : fn;
+
 	memset(sumhash, 0, SR_SUMHASHLEN);
 	sumhash[0] = algo;
 
@@ -737,6 +740,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	}
 	/* end of xattr check */
 
+	fprintf(stderr, "checksumming %c\n", algo);
 	switch (algo) {
 
 	case '0':
@@ -783,7 +787,6 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		md = EVP_md5();
 		EVP_DigestInit_ex(ctx, md, NULL);
 
-		just_the_name = just_the_name ? just_the_name + 1 : fn;
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
@@ -794,7 +797,6 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		md = EVP_md5();
 		EVP_DigestInit_ex(ctx, md, NULL);
 
-		just_the_name = just_the_name ? just_the_name + 1 : fn;
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
@@ -805,7 +807,6 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		md = EVP_md5();
 		EVP_DigestInit_ex(ctx, md, NULL);
 
-		just_the_name = just_the_name ? just_the_name + 1 : fn;
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
@@ -824,8 +825,6 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'R':		// null, or removal.
-		just_the_name = rindex(fn, '/') + 1;
-		just_the_name = just_the_name ? just_the_name + 1 : fn;
 		ctx = EVP_MD_CTX_create();
 		md = EVP_sha512();
 		EVP_DigestInit_ex(ctx, md, NULL);
@@ -839,9 +838,6 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		ctx = EVP_MD_CTX_create();
 		md = EVP_sha512();
 		EVP_DigestInit_ex(ctx, md, NULL);
-
-		just_the_name = rindex(fn, '/') + 1;
-		just_the_name = just_the_name ? just_the_name + 1 : fn;
 
 		strcpy(buf, just_the_name);
 		sprintf(buf, "%s%c,%lu,%lu,%lu,%lu", just_the_name, algo,

--- a/sr_util.c
+++ b/sr_util.c
@@ -692,8 +692,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
     block starts at block_size * block_num, and ends 
   */
 {
-	EVP_MD_CTX *ctx;
-	const EVP_MD *md;
+	EVP_MD_CTX *ctx=NULL;
 	char *sumstrptr;
 	//static char sumstr[SR_SUMSTRLEN];
 	unsigned int hashlen = 0;
@@ -740,7 +739,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	}
 	/* end of xattr check */
 
-	fprintf(stderr, "checksumming %c\n", algo);
+	fprintf(stderr, "checksumming %c SR_SUMSTRLEN=%d\n", algo, SR_SUMSTRLEN);
 	switch (algo) {
 
 	case '0':
@@ -748,9 +747,8 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'd':
-		ctx = EVP_MD_CTX_create();
-		md = EVP_md5();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 		// keep file open through repeated calls.
 		//fprintf( stderr, "opening %s to checksum\n", fn );
 
@@ -758,6 +756,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		if (fd < 0) {
 			fprintf(stderr, "unable to read file for checksumming\n");
 			strcpy(sumstrptr + 3, "deadbeef0");
+		        EVP_MD_CTX_free(ctx);
 			return (NULL);
 		}
 		lseek(fd, start, SEEK_SET);
@@ -773,6 +772,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 			} else {
 				fprintf(stderr, "error reading %s for MD5\n", fn);
 				close(fd);
+		                EVP_MD_CTX_free(ctx);
 				return (NULL);
 			}
 		}
@@ -783,9 +783,8 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'm':		// mkdir
-		ctx = EVP_MD_CTX_create();
-		md = EVP_md5();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -793,9 +792,8 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'r':		// rmdir
-		ctx = EVP_MD_CTX_create();
-		md = EVP_md5();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -803,9 +801,8 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'n':
-		ctx = EVP_MD_CTX_create();
-		md = EVP_md5();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -815,9 +812,8 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	case 'l':
 	case 'L':		// symlink case
 		just_the_name = linkstr;
-		ctx = EVP_MD_CTX_create();
-		md = EVP_sha512();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
 
 		EVP_DigestUpdate(ctx, linkstr, strlen(linkstr));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -825,19 +821,20 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'R':		// null, or removal.
-		ctx = EVP_MD_CTX_create();
-		md = EVP_sha512();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		fprintf(stderr, "checksumming remove 1\n");
+		ctx = EVP_MD_CTX_new();
+		fprintf(stderr, "checksumming remove 2 ctx=%p\n", ctx);
+		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
 
+		fprintf(stderr, "checksumming remove 3 back from init, just_the_name=%s\n", just_the_name );
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
 		break;
 
 	case 'p':
-		ctx = EVP_MD_CTX_create();
-		md = EVP_sha512();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
 
 		strcpy(buf, just_the_name);
 		sprintf(buf, "%s%c,%lu,%lu,%lu,%lu", just_the_name, algo,
@@ -848,13 +845,13 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 's':
-		ctx = EVP_MD_CTX_create();
-		md = EVP_sha512();
-		EVP_DigestInit_ex(ctx, md, NULL);
+		ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
 
 		fd = open(fn, O_RDONLY);
 		if (fd < 0) {
 			fprintf(stderr, "unable to read file for SHA checksumming\n");
+		        EVP_MD_CTX_free(ctx);
 			return (NULL);
 		}
 		lseek(fd, start, SEEK_SET);
@@ -874,6 +871,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 			} else {
 				fprintf(stderr, "error reading %s for SHA\n", fn);
 				close(fd);
+		                EVP_MD_CTX_free(ctx);
 				return (NULL);
 			}
 		}
@@ -895,6 +893,9 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		return (NULL);
 	}
 
+	if (ctx) {
+		EVP_MD_CTX_free(ctx);
+        }
 	/* xattr set for checksum caching optimization */
 	if (xattr_cc) {
 		// can we set xattrs? let's try and find out!
@@ -904,6 +905,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		// if the calls above fail, ignore and proceed
 	}
 	/* end of xattr set */
+        fprintf(stderr, "sr_setsumstr returning: %s\n", sumstrptr );
 
 	return (sumstrptr);
 }

--- a/sr_util.c
+++ b/sr_util.c
@@ -739,7 +739,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	}
 	/* end of xattr check */
 
-	fprintf(stderr, "checksumming %c SR_SUMSTRLEN=%d\n", algo, SR_SUMSTRLEN);
+	fprintf(stderr, "SR_DEBUG FIXME: checksumming %c SR_SUMSTRLEN=%d\n", algo, SR_SUMSTRLEN);
 	switch (algo) {
 
 	case '0':
@@ -748,7 +748,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 'd':
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+		EVP_DigestInit(ctx, EVP_md5());
 		// keep file open through repeated calls.
 		//fprintf( stderr, "opening %s to checksum\n", fn );
 
@@ -784,7 +784,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 'm':		// mkdir
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+		EVP_DigestInit(ctx, EVP_md5() );
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -793,7 +793,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 'r':		// rmdir
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+		EVP_DigestInit(ctx, EVP_md5());
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -802,7 +802,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 'n':
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+		EVP_DigestInit(ctx, EVP_md5());
 
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -813,7 +813,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	case 'L':		// symlink case
 		just_the_name = linkstr;
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
+		EVP_DigestInit(ctx, EVP_sha512());
 
 		EVP_DigestUpdate(ctx, linkstr, strlen(linkstr));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
@@ -821,12 +821,12 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'R':		// null, or removal.
-		fprintf(stderr, "checksumming remove 1\n");
+		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 1\n");
 		ctx = EVP_MD_CTX_new();
-		fprintf(stderr, "checksumming remove 2 ctx=%p\n", ctx);
-		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
+		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 2 ctx=%p\n", ctx);
+		EVP_DigestInit(ctx, EVP_sha512());
 
-		fprintf(stderr, "checksumming remove 3 back from init, just_the_name=%s\n", just_the_name );
+		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 3 back from init, just_the_name=%s\n", just_the_name );
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
@@ -834,7 +834,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 'p':
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
+		EVP_DigestInit(ctx, EVP_sha512());
 
 		strcpy(buf, just_the_name);
 		sprintf(buf, "%s%c,%lu,%lu,%lu,%lu", just_the_name, algo,
@@ -846,7 +846,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 
 	case 's':
 		ctx = EVP_MD_CTX_new();
-		EVP_DigestInit_ex(ctx, EVP_sha512(), NULL);
+		EVP_DigestInit(ctx, EVP_sha512());
 
 		fd = open(fn, O_RDONLY);
 		if (fd < 0) {
@@ -905,7 +905,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		// if the calls above fail, ignore and proceed
 	}
 	/* end of xattr set */
-        fprintf(stderr, "sr_setsumstr returning: %s\n", sumstrptr );
+        fprintf(stderr, "SR_DEBUG FIXME: sr_setsumstr returning: %s\n", sumstrptr );
 
 	return (sumstrptr);
 }


### PR DESCRIPTION
close #198 

I have been working on the hpc-mirorring, finding edge cases that don´t work.  One such case is events to reflect directory removals.  I noticed that, as per #198 the events produced by the C  for rmdir events (or rm -rf) were not being produced with the correct fileOp field:

* "fileOp" : { "remove":"" },

when it should have:

* "fileOp" : { "remove":"", "directory":"" }

on the Python side, you need the  both attributes when trying to mirror an rmdir.

So that was one problem.  Another problem was that when doing something like "rm -rf" some of the remove events are for directories.  The way to create a file removal event with the current API is to provide a NULL pointer to the file status struct.  The file status struct normally provides the file type (file, directory link, etc...)
since the removal event doesn't have this information, the API needs to be changed to allow communicating
that the file being removed is a directory.   so added *rmflags* to a whole slew of routines (two or three levels deep.) 

```

   const int rmflags 
   * 0 -- sb MUST not be null, this is not a remove event.
   * 1 -- sb==NULL this is a file (non-directory) removal.
   * 2 -- sb==NULL this is a directory removal.

```

So that's the logic for #198... Unfortunately I was working on that in a branch that was originally about #196.  I tried cherry-picking off the above to just PR cleanly for #198, but it turned out these patches depend on the earlier ones... so I needed to PR the whole thing.

The rest of these patches are cleanups that try to make the code cleaner, while testing thoughts about #196.
None of them fix it. 

My guess as to the real problem is for #196:   when we add process cleanup routine, it gets added after posix thread cleanup has occurred. when we  try to close a file, it calls posix thread code where those data structures have already been cleaned up.

So what are these patches?

* 5fc86ae5882aad0cebefac3a6c7028d4ad727795  segfaults were happenning when calling hash functions, so got rid of some times when calling those routinges is useless.   but since we aren't calling the routines this could change results... but when I ran the flow tests... it seemed fine... 
*  1719b3984a5c602cfe4fd7038c4154d0a541ffa9 - reference through un-initialized pointer... looked wrong.
* 34773816a42d559e6254321c1116fb4cd1ec7d03 -- SSL hash initialization routines... we were using a very old API, (and it was crashing in it.) so I changed it to use a newer API version.  It didn't change anything though.
*  688edcbbbdab8f2bbe55998e21ae3eac65cc8d39 -- SR_SHIMDEBUG log outputs weren't working because any time they were set, it would suppress messages... (a test was inverted.)


