### PR TITLE
log the correct string for fileAgeMin/fileAgeMax + test OS changes

### DIFF
--- a/.github/workflows/shim_test.yml
+++ b/.github/workflows/shim_test.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ "test_shim_post", "test_shim_copy_mirror", "test_shim_copy_strip", "test_shim_copy_strip_slash", "test_shim_copy_baseDir" ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ unit ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/sr_post.c
+++ b/sr_post.c
@@ -755,7 +755,10 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 
 		// if post_baseDir didn't match, try realpath_post_baseDir
 		} else {
-			drfound = strstr(fn, (sr_c->cfg->realpath_post_baseDir)+1);
+			drfound = NULL;
+			if (sr_c->cfg->realpath_post_baseDir && (strlen(sr_c->cfg->realpath_post_baseDir) > 1)) {
+				drfound = strstr(fn, (sr_c->cfg->realpath_post_baseDir)+1);
+			}
 			if (drfound==fn+1) {
 				pbdlen = strlen(sr_c->cfg->realpath_post_baseDir);
 				drfound += (sr_c->cfg->realpath_post_baseDir[pbdlen-1] == '/') ? pbdlen - 1 : pbdlen; //adjust for trailing /

--- a/sr_post.c
+++ b/sr_post.c
@@ -676,13 +676,13 @@ int sr_file2message_start(struct sr_context *sr_c, const char *pathspec,
 	       time_t age = time(NULL)-sb->st_mtime ;
 	       if ((sr_c->cfg->nodupe_fileAgeMax>0) && (age > sr_c->cfg->nodupe_fileAgeMax )) {
 	                if (sr_c->cfg->logReject) {
-			     sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "rejecting older than %g: ignoring %s\n", sr_c->cfg->nodupe_fileAgeMax, fn );
+			     sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "rejecting older than %g: ignoring %s\n", sr_c->cfg->nodupe_fileAgeMax, pathspec );
        		         }
  			return(0);
 	       }
 	       if ((sr_c->cfg->nodupe_fileAgeMin>0) && (age < sr_c->cfg->nodupe_fileAgeMin )) {
 	                if (sr_c->cfg->logReject) {
-			     sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "rejecting newer than %g: ignoring %s\n", sr_c->cfg->nodupe_fileAgeMin, fn );
+			     sr_log_msg(sr_c->cfg->logctx,LOG_INFO, "rejecting newer than %g: ignoring %s\n", sr_c->cfg->nodupe_fileAgeMin, pathspec );
        		         }
  			return(0);
 	       }


### PR DESCRIPTION
For #202. This doesn't change the behaviour, but the correct path will be logged so it will be easier to debug

I also changed the OSes that the GitHub Actions tests run on. I'm curious if we'll run into the compilation errors on 24.04 or not.