### PR TITLE
Fix another spot where 0 was passed to post for removals

### DIFF
--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -872,7 +872,7 @@ int unlinkat(int dirfd, const char *path, int flags)
 		return status;
 
 	if (dirfd == AT_FDCWD)
-		return (shimpost(path, status, 0));
+		return (shimpost(path, status, isdir?2:1));
 
 	snprintf(fdpath, 32, "/proc/self/fd/%d", dirfd);
 	real_return = realpath(fdpath, real_path);

--- a/sr_util.c
+++ b/sr_util.c
@@ -739,7 +739,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 	}
 	/* end of xattr check */
 
-	fprintf(stderr, "SR_DEBUG FIXME: checksumming %c SR_SUMSTRLEN=%d\n", algo, SR_SUMSTRLEN);
+	// fprintf(stderr, "SR_DEBUG FIXME: checksumming %c SR_SUMSTRLEN=%d\n", algo, SR_SUMSTRLEN);
 	switch (algo) {
 
 	case '0':
@@ -821,12 +821,12 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		break;
 
 	case 'R':		// null, or removal.
-		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 1\n");
+		// fprintf(stderr, "SR_DEBUG FIXME checksumming remove 1\n");
 		ctx = EVP_MD_CTX_new();
-		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 2 ctx=%p\n", ctx);
+		// fprintf(stderr, "SR_DEBUG FIXME checksumming remove 2 ctx=%p\n", ctx);
 		EVP_DigestInit(ctx, EVP_sha512());
 
-		fprintf(stderr, "SR_DEBUG FIXME checksumming remove 3 back from init, just_the_name=%s\n", just_the_name );
+		// fprintf(stderr, "SR_DEBUG FIXME checksumming remove 3 back from init, just_the_name=%s\n", just_the_name );
 		EVP_DigestUpdate(ctx, just_the_name, strlen(just_the_name));
 		EVP_DigestFinal_ex(ctx, sumhash + 1, &hashlen);
 		sr_hash2sumstr(sumstrptr, sumhash);
@@ -905,7 +905,7 @@ char *sr_set_sumstr(char algo, char algoz, const char *fn, const char *partstr,
 		// if the calls above fail, ignore and proceed
 	}
 	/* end of xattr set */
-        fprintf(stderr, "SR_DEBUG FIXME: sr_setsumstr returning: %s\n", sumstrptr );
+	// fprintf(stderr, "SR_DEBUG FIXME: sr_setsumstr returning: %s\n", sumstrptr );
 
 	return (sumstrptr);
 }


### PR DESCRIPTION
I also commented out the debugging logs in the checksumming code.

---

One thing I'm curious about: we have a stat buffer in the `unlinkat` function, then we call `shimpost` which calls `srshim_realpost` and in there, it calls `lstat` again:

https://github.com/MetPX/sarrac/blob/7bf2cf22d757e354b5d71bae950f1ea8297b8edd/libsr3shim.c#L476-L503
...
https://github.com/MetPX/sarrac/blob/7bf2cf22d757e354b5d71bae950f1ea8297b8edd/libsr3shim.c#L541-L550

By the time shimpost is called, the unlink has already happened, so the `lstat` inside srshim_realpost fails.  But couldn't we pass in the sb that we already had before doing the unlink and skip calling lstat inside srshim_realpost? 