### PR TITLE
Fix #177 (output redirection not posted) and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ format:
 
 clean:
 	rm -f *.o *.gcno *.so *.so.* *.links lovelylinkforu sr3_cpost sr_configtest sr_utiltest sr3_cpump sr_cachetest sr_cache_save.test shim_test.log call_remove 
+	rm -rf shim_dirA shim_dirB shim_dirC dir*.sums dir*.links shim_*.log 
 	rm -rf build sr_version.h metpx-sr3c_rhel7.spec dir?.links
 	-sr3 cleanup cpost/local_post
 	-sr3 cleanup subscribe/local_copy

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-metpx-sr3c (3.25.03rc1) UNRELEASED; urgency=medium
+metpx-sr3c (3.25.03rc2) UNRELEASED; urgency=medium
+
+  * fix #177 files written using redirection are not posted
+
+ -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Thu, 27 Mar 2025 21:32:06 +0000
+
+metpx-sr3c (3.25.03rc1) unstable; urgency=medium
 
   * fix #199 not posting when regex does not match
   * fix #198 rm -rf make file remove events instead of directory ones.

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -1118,12 +1118,6 @@ int dup2(int oldfd, int newfd)
 		return dup2_fn_ptr(oldfd, newfd);
 	}
 
-	if (!strncmp(real_path, "/dev/", 5) || !strncmp(real_path, "/proc/", 6)) {
-		sr_shimdebug_msg(4, " dup2 NO POST path device or proc !\n");
-		errno = 0;
-		return dup2_fn_ptr(oldfd, newfd);
-	}
-
 	if (!getenv("SR_POST_READS"))
 		srshim_initialize("shim");
 
@@ -1133,6 +1127,12 @@ int dup2(int oldfd, int newfd)
 		sr_shimdebug_msg(4,
 				 " dup2 newfd is open, so close it explicitly to potentially post.\n");
 		close(newfd);
+	}
+
+	if (!strncmp(real_path, "/dev/", 5) || !strncmp(real_path, "/proc/", 6)) {
+		sr_shimdebug_msg(4, " dup2 NO POST path device or proc !\n");
+		errno = 0;
+		return dup2_fn_ptr(oldfd, newfd);
 	}
 
 	status = dup2_fn_ptr(oldfd, newfd);
@@ -1199,12 +1199,6 @@ int dup3(int oldfd, int newfd, int flags)
 		return dup3_fn_ptr(oldfd, newfd, flags);
 	}
 
-	if (!strncmp(real_path, "/dev/", 5) || !strncmp(real_path, "/proc/", 6)) {
-		sr_shimdebug_msg(4, " dup3 NO POST path device or proc !\n");
-		errno = 0;
-		return dup3_fn_ptr(oldfd, newfd, flags);
-	}
-
 	if (!getenv("SR_POST_READS"))
 		srshim_initialize("shim");
 
@@ -1213,6 +1207,12 @@ int dup3(int oldfd, int newfd, int flags)
 		sr_shimdebug_msg(4,
 				 " dup3 newfd is open, so close it explicitly to potentially post.\n");
 		close(newfd);
+	}
+
+	if (!strncmp(real_path, "/dev/", 5) || !strncmp(real_path, "/proc/", 6)) {
+		sr_shimdebug_msg(4, " dup3 NO POST path device or proc !\n");
+		errno = 0;
+		return dup3_fn_ptr(oldfd, newfd, flags);
 	}
 
 	errno = 0;

--- a/libsr3shim.c
+++ b/libsr3shim.c
@@ -308,7 +308,7 @@ int should_not_post(const char *fn, const int rmflags)
 
 	/* if already seen, then return (either too soon, or OK!) */
 	for (int i = 0; i < remembered_count; i++) {
-		sr_shimdebug_msg(5, "looking at remembered files %d\n", i);
+		sr_shimdebug_msg(5, "looking at remembered file %d %s\n", i, (*remembered_filenames)[i].name);
 		if (!strcmp((*remembered_filenames)[i].name, fn)) {
 			interval = (ts.tv_sec + ts.tv_nsec / 1e9) -
 			    ((*remembered_filenames)[i].ts.tv_sec +

--- a/shim_copy_baseDir.sh
+++ b/shim_copy_baseDir.sh
@@ -50,7 +50,8 @@ logMessageDump on
 callback log
 batch 1
 mirror True
-baseDir `pwd`/shim_dirA
+# cpost is posting realpaths, this has to match what it posts
+baseDir `realpath $(pwd)`/shim_dirA
 directory `pwd`/shim_dirB
 accept .*`realpath .`/.*
 accept .*`realpath ${HOME}/test`/.*

--- a/shim_copy_baseDir.sh
+++ b/shim_copy_baseDir.sh
@@ -107,11 +107,8 @@ else
 fi
 export SR_SHIMDEBUG=99
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-    bash ./shim_copy_post2.sh &
-else
-    ./shim_copy_post2.sh &
-fi
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post2.sh &
 
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG

--- a/shim_copy_flatten.sh
+++ b/shim_copy_flatten.sh
@@ -104,11 +104,9 @@ else
    export LD_LIBRARY_PATH=`pwd`:${LD_LIBRARY_PATH}
 fi
 export SR_SHIMDEBUG=99
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-     bash ./shim_copy_post.sh &
-else
-     ./shim_copy_post.sh &
-fi
+
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post.sh &
      
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG

--- a/shim_copy_mirror.sh
+++ b/shim_copy_mirror.sh
@@ -108,11 +108,8 @@ else
 fi
 export SR_SHIMDEBUG=99
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then 
-    bash ./shim_copy_post2.sh &
-else
-    ./shim_copy_post2.sh &
-fi
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post2.sh &
 
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG

--- a/shim_copy_mirror.sh
+++ b/shim_copy_mirror.sh
@@ -87,7 +87,7 @@ nodupe_ttl 0
 header toto=pig
 events modify,link,delete,mkdir,rmdir
 
-post_baseUrl file:`pwd`/shim_dirA
+post_baseUrl file:`realpath $(pwd)`/shim_dirA
 post_topicPrefix v03.post
 
 accept `realpath .`/.*

--- a/shim_copy_mirror_sftp.sh
+++ b/shim_copy_mirror_sftp.sh
@@ -104,11 +104,8 @@ else
 fi
 export SR_SHIMDEBUG=99
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-    bash ./shim_copy_post2.sh &
-else
-    ./shim_copy_post2.sh &
-fi
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post2.sh &
 
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG

--- a/shim_copy_mirror_sftp.sh
+++ b/shim_copy_mirror_sftp.sh
@@ -83,7 +83,7 @@ nodupe_ttl 0
 header toto=pig
 events modify,link,delete,mkdir,rmdir
 
-post_baseUrl sftp://${USER}@localhost/`pwd`/shim_dirA
+post_baseUrl sftp://${USER}@localhost/`realpath $(pwd)`/shim_dirA
 post_topicPrefix v03.post
 
 accept `realpath .`/.*

--- a/shim_copy_post.sh
+++ b/shim_copy_post.sh
@@ -4,9 +4,8 @@ set -x
 cd shim_dirA
 which bash
 
-echo "FIXME: KNOWN ISSUE redirection close does not get posted!"
-#echo "#test 1 sha512 000 capturing stdout"
-#bash -c 'echo "hoho" >> ./hoho'
+echo "#test 1 sha512 000 capturing stdout"
+echo "hoho" >> ./hoho
 
 echo "#test 0 comment 010 shim copy posting start"
 echo "#test 1 sha512 c program run."

--- a/shim_copy_post.sh
+++ b/shim_copy_post.sh
@@ -106,10 +106,11 @@ mv test_file dirthree
 echo "#test 1 sha512 162 create test_file (again)"
 echo 2 >test_file
 
-if [ ! "${KNOWN_REDIRECTION_BUG}" ]; then
-    echo "#no post from touch, refused as repeat"
-    touch test_file
-fi
+# doing both redirection and touch produces two posts
+#if [ ! "${KNOWN_REDIRECTION_BUG}" ]; then
+#    echo "#no post from touch, refused as repeat"
+#    touch test_file
+#fi
 
 echo "#test 1 rename move test_file into dirthree subdir (new name)"
 mv test_file dirthree/new_test_file

--- a/shim_copy_post.sh
+++ b/shim_copy_post.sh
@@ -103,7 +103,10 @@ touch test_file
 echo "#test 1 rename 152 move test_file into dirthree subdir"
 mv test_file dirthree
 
-echo "#test 1 sha512 162 create test_file (again)"
+# sleep to ensure that shim_post_minterval doesn't suppress the post of test_file
+sleep 10
+
+echo "#test 1 sha512 162 create test_file (again) using redirection"
 echo 2 >test_file
 
 # doing both redirection and touch produces two posts

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -4,10 +4,11 @@ set -x
 cd shim_dirA
 which bash
 
+echo "#test 0 comment 010 shim copy posting start"
+
 echo "#test 1 sha512 000 capturing stdout"
 echo "hoho" >> ./hoho
 
-echo "#test 0 comment 010 shim copy posting start"
 echo "#test 1 sha512 c program run."
 truncate --size=2 ./hoho
 

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -4,15 +4,8 @@ set -x
 cd shim_dirA
 which bash
 
-echo "FIXME: KNOWN ISSUE redirection close does not get posted!"
-
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-    echo "#test 1 sha512 000 work-around for capturing stdout"
-    cp ../pyiotest ./hoho
-else
-    echo "#test 1 sha512 000 capturing stdout"
-    bash -c 'echo "hoho" >> ./hoho'
-fi
+echo "#test 1 sha512 000 capturing stdout"
+echo "hoho" >> ./hoho
 
 echo "#test 0 comment 010 shim copy posting start"
 echo "#test 1 sha512 c program run."
@@ -36,7 +29,7 @@ echo "#test 1 link 050 symlink to a broken place"
 ln -sf broken_do_not_exist symlink_to_non_existent_place
 
 echo "#test 1 link 050 symlink to a broken place"
-ln -sf `pwd`/broken_do_not_exist `pwd`/symlink_to_non_existent_place
+ln -sf `pwd`/broken_do_not_exist2 `pwd`/symlink_to_non_existent_place2
 
 echo "#test 1 sha512 050 touch command"
 touch hihi
@@ -120,13 +113,17 @@ touch test_file
 
 echo "#test 1 rename move test_file into dirthree subdir"
 mv test_file dirthree
+
+# sleep to ensure that shim_post_minterval doesn't suppress the post of test_file
+sleep 10
+
 echo "#test 1 sha512 create test_file (again) from redirection"
 echo 2 >test_file
 
-if [ ! "${KNOWN_REDIRECTION_BUG}" ]; then
-    echo "#no post from touch, refused as repeat"
-    touch test_file
-fi
+#if [ ! "${KNOWN_REDIRECTION_BUG}" ]; then
+#    echo "#no post from touch, refused as repeat"
+#    touch test_file
+#fi
 
 echo "#test 1 rename move test_file into dirthree subdir (new name)"
 mv test_file dirthree/new_test_file

--- a/shim_copy_strip.sh
+++ b/shim_copy_strip.sh
@@ -118,11 +118,9 @@ else
 fi
 export SR_SHIMDEBUG=99
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-	bash ./shim_copy_post.sh &
-else
-	./shim_copy_post.sh &
-fi
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post.sh &
+
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG
 unset LD_PRELOAD

--- a/shim_copy_strip.sh
+++ b/shim_copy_strip.sh
@@ -93,7 +93,8 @@ nodupe_ttl 0
 header toto=pig
 events modify,link,delete,mkdir,rmdir
 
-post_baseUrl file:`pwd`/shim_dirA
+# needs to match the subscribe configs accepts, which use realpath
+post_baseUrl file:`realpath $(pwd)`/shim_dirA
 post_topicPrefix v03.post
 
 accept `realpath .`/.*

--- a/shim_copy_strip.sh
+++ b/shim_copy_strip.sh
@@ -34,7 +34,7 @@ if [ ! "${EXCHANGE}" ]; then
     EXCHANGE=xs_feed
 fi
 
-STRIP="`pwd`"
+STRIP="`realpath $(pwd)`"
 STRIP="`echo ${STRIP} | tr -cd '/' | wc -c`"
 STRIP=$((${STRIP}+1))
 

--- a/shim_copy_strip_slash.sh
+++ b/shim_copy_strip_slash.sh
@@ -111,11 +111,9 @@ else
 fi
 export SR_SHIMDEBUG=99
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-	bash ./shim_copy_post.sh &
-else
-	./shim_copy_post.sh &
-fi
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_copy_post.sh &
+
 unset SR_POST_CONFIG
 unset SR_SHIMDEBUG
 unset LD_PRELOAD

--- a/shim_copy_strip_slash.sh
+++ b/shim_copy_strip_slash.sh
@@ -34,11 +34,11 @@ if [ ! "${EXCHANGE}" ]; then
     EXCHANGE=xs_feed
 fi
 
-STRIP="`pwd`"
+STRIP="`realpath $(pwd)`"
 STRIP="`echo ${STRIP} | tr -cd '/' | wc -c`"
 STRIP=$((${STRIP}+1))
 
-echo "setting STRIP to $STRIP for: `pwd`"
+echo "setting STRIP to $STRIP for: `pwd` (realpath: `realpath $(pwd)`)"
 
 cat >~/.config/sr3/subscribe/local_copy.conf <<EOT
 

--- a/shim_post.sh
+++ b/shim_post.sh
@@ -68,10 +68,6 @@ EOT
    exec $0
 fi
 
-if [ "${KNOWN_REDIRECTION_BUG}" ];then
-    bash ./shim_post_run.sh
-else
-    . ./shim_post_run.sh
-fi
-
+# run in a new shell to ensure output redirection correctly triggers posts #177
+bash ./shim_post_run.sh
 

--- a/shim_post_run.sh
+++ b/shim_post_run.sh
@@ -51,26 +51,16 @@ echo "#test 1 remove 140 removing a file."
 rm ~/test/hoho2.log
 
 echo "#test 1 directory 150 make second directory ."
-
 mkdir dirone
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-    echo "#test 1 sha512 160 cp to avoid stdout redirection in a subdir"
-    cp hoho dirone/fileone
-else
-    echo "#test 1 sha512 160 stdout redirection in a subdir"
-    echo "fileone" >>dirone/fileone
-fi
+
+echo "#test 1 sha512 160 stdout redirection in a subdir"
+echo "fileone" >>dirone/fileone
 
 echo "#test 1 directory 170 make third directory."
 mkdir dirone/dirtwo
 
-if [ "${KNOWN_REDIRECTION_BUG}" ]; then
-    echo "#test 1 sha512 180 cp to avoid stdout redirection in a subsubdir"
-    cp hoho dirone/dirtwo/filetwo
-else
-    echo "#test 1 sha512 180 stdout redirection in a subsubdir"
-    echo "filetwo" >>dirone/dirtwo/filetwo
-fi
+echo "#test 1 sha512 180 stdout redirection in a subsubdir"
+echo "filetwo" >>dirone/dirtwo/filetwo
 
 echo "#test 1 sha512 160 copy a file to one with spaces in the name"
 cp dirone/dirtwo/filetwo "dirone/filetwo copy with spaces in the name"


### PR DESCRIPTION
This merges my redirection fix from November (discussed in #177). With the test changes, I feel pretty confident now that it's a good change. The behaviour is consistent across all the OSes now.

It also makes changes to the tests. The KNOWN_REDIRECTION_BUG cases are removed and now all tests run by `make test_shim` pass completely on Ubuntu 18, 20, 22, RHEL 8 and 9, including RHEL 8 on PPP. There are some issues on Ubuntu 24 that I haven't looked into yet.

Most of the changes required to get the tests passing on the supercomputer were related to the symlinked home directories and using realpath in the configs. I know we were hesitant to change realpath stuff in the test configs before, but we fixed some realpath weirdness in the code in #186 and now I'm pretty sure the paths being posted are good. 