### PR TITLE
Fix #208

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,11 @@
-metpx-sr3c (3.25.03rc2) UNRELEASED; urgency=medium
+metpx-sr3c (3.25.03rc3) UNRELEASED; urgency=medium
+
+  * fix #208 directory removals with trailing slashes are not posted correctly
+    when using realpathAdjust
+
+ -- Reid Sunderland <reid.sunderland@ssc-spc.gc.ca>  Wed, 02 Apr 2025 19:35:00 +0000
+
+metpx-sr3c (3.25.03rc2) unstable; urgency=medium
 
   * fix #177 files written using redirection are not posted
 

--- a/shim_copy_post.sh
+++ b/shim_copy_post.sh
@@ -117,4 +117,11 @@ echo 2 >test_file
 echo "#test 1 rename move test_file into dirthree subdir (new name)"
 mv test_file dirthree/new_test_file
 
+# issue #208 rm directory with trailing slash
+echo "#test 1 directory create with trailing slash"
+mkdir dir_test/
+
+echo "#test 1 remove directory with trailing slash"
+rm -r dir_test/
+
 echo "#test 0 comment 160 shim copy posting end"

--- a/shim_copy_post2.sh
+++ b/shim_copy_post2.sh
@@ -29,6 +29,13 @@ ln hoho hard_link_to_hoho
 echo "#test 1 link 050 symlink to a broken place"
 ln -sf broken_do_not_exist symlink_to_non_existent_place
 
+# (re-) creating a symlink that already exists should generate two messages
+# one link with a temporary name and one rename that renames the temporary name to the
+# correct name, and overwrites the already existing symlink in the process
+
+echo "#test 1,1 link,rename 050 symlink to a broken place"
+ln -sf broken_do_not_exist symlink_to_non_existent_place
+
 echo "#test 1 link 050 symlink to a broken place"
 ln -sf `pwd`/broken_do_not_exist2 `pwd`/symlink_to_non_existent_place2
 
@@ -136,5 +143,12 @@ rm filefive
 
 echo "#test 1 rename move a file when in a linked dir.)"
 mv new_test_file middle_aged_test_file
+
+# issue #208 rm directory with trailing slash
+echo "#test 1 directory create with trailing slash"
+mkdir dir_test/
+
+echo "#test 1 remove directory with trailing slash"
+rm -r dir_test/
 
 echo "#test 0 comment 160 shim copy posting end"

--- a/sr_post.c
+++ b/sr_post.c
@@ -594,6 +594,7 @@ void realpath_adjust(struct sr_log_context_s *logctx, const char *input_path, ch
 	char *return_value;
 	char mutable_input_path[PATH_MAX];
 	int i;
+	bool ends_with_slash = false;
 
 	i = 0;
 	end = NULL;
@@ -610,7 +611,11 @@ void realpath_adjust(struct sr_log_context_s *logctx, const char *input_path, ch
 		adjust = -1;
 	}
 	if (adjust < 0) {
-		for (i = 0; i > adjust; i--) {
+		// handle paths that end in slash
+		int pathlen = strlen(start);
+		ends_with_slash = (pathlen > 0 && start[pathlen-1] == '/');
+		sr_log_msg(logctx,LOG_DEBUG, "realpath_adjust %d, %s ends with slash? %d \n", adjust, input_path, ends_with_slash);
+		for (i = 0; i > (adjust - (ends_with_slash ? 1:0)); i--) {
 			spare = end;
 			end = strrchr(start, '/');
 			if (end) {


### PR DESCRIPTION
This fixes #208.

When realpathAdjust is < 0 and the input path to realpath_adjust ends in `/`, it ignores the trailing slash and does the adjustment as if it wasn't there.